### PR TITLE
fix: rename exam IDs and names to official Salesforce certification titles

### DIFF
--- a/migrations/0006_rename_exam_ids.sql
+++ b/migrations/0006_rename_exam_ids.sql
@@ -1,0 +1,83 @@
+-- Migration 0006: Rename exam IDs to official Salesforce certification names
+-- and fix display names for all exams (separate JA/EN names)
+
+-- Step 1: Insert new exam rows with correct JA/EN names
+INSERT OR IGNORE INTO exams (id, name, lang) VALUES
+  ('mulesoft_developer_exam',                          'Salesforce 認定 MuleSoft デベロッパー',                      'ja'),
+  ('mulesoft_developer_exam_en',                       'Salesforce Certified MuleSoft Developer',                    'en'),
+  ('mulesoft_platform_integration_architect_exam',     'Salesforce 認定 MuleSoft Platform Integration アーキテクト', 'ja'),
+  ('mulesoft_platform_integration_architect_exam_en',  'Salesforce Certified MuleSoft Platform Integration Architect','en');
+
+-- Step 2: Migrate questions for mule_dev_201_exam → mulesoft_developer_exam
+UPDATE questions
+  SET id = REPLACE(id, 'mule_dev_201_exam__', 'mulesoft_developer_exam__'),
+      exam_id = 'mulesoft_developer_exam'
+  WHERE exam_id = 'mule_dev_201_exam';
+
+UPDATE questions
+  SET id = REPLACE(id, 'mule_dev_201_exam_en__', 'mulesoft_developer_exam_en__'),
+      exam_id = 'mulesoft_developer_exam_en'
+  WHERE exam_id = 'mule_dev_201_exam_en';
+
+-- Step 3: Migrate questions for plat_arch_202_exam → mulesoft_platform_integration_architect_exam
+UPDATE questions
+  SET id = REPLACE(id, 'plat_arch_202_exam__', 'mulesoft_platform_integration_architect_exam__'),
+      exam_id = 'mulesoft_platform_integration_architect_exam'
+  WHERE exam_id = 'plat_arch_202_exam';
+
+UPDATE questions
+  SET id = REPLACE(id, 'plat_arch_202_exam_en__', 'mulesoft_platform_integration_architect_exam_en__'),
+      exam_id = 'mulesoft_platform_integration_architect_exam_en'
+  WHERE exam_id = 'plat_arch_202_exam_en';
+
+-- Step 4: Update question_history.question_id
+UPDATE question_history
+  SET question_id = REPLACE(question_id, 'mule_dev_201_exam__', 'mulesoft_developer_exam__')
+  WHERE question_id LIKE 'mule_dev_201_exam__%';
+
+UPDATE question_history
+  SET question_id = REPLACE(question_id, 'mule_dev_201_exam_en__', 'mulesoft_developer_exam_en__')
+  WHERE question_id LIKE 'mule_dev_201_exam_en__%';
+
+UPDATE question_history
+  SET question_id = REPLACE(question_id, 'plat_arch_202_exam__', 'mulesoft_platform_integration_architect_exam__')
+  WHERE question_id LIKE 'plat_arch_202_exam__%';
+
+UPDATE question_history
+  SET question_id = REPLACE(question_id, 'plat_arch_202_exam_en__', 'mulesoft_platform_integration_architect_exam_en__')
+  WHERE question_id LIKE 'plat_arch_202_exam_en__%';
+
+-- Step 5: Update scores.question_id
+UPDATE scores
+  SET question_id = REPLACE(question_id, 'mule_dev_201_exam__', 'mulesoft_developer_exam__')
+  WHERE question_id LIKE 'mule_dev_201_exam__%';
+
+UPDATE scores
+  SET question_id = REPLACE(question_id, 'mule_dev_201_exam_en__', 'mulesoft_developer_exam_en__')
+  WHERE question_id LIKE 'mule_dev_201_exam_en__%';
+
+UPDATE scores
+  SET question_id = REPLACE(question_id, 'plat_arch_202_exam__', 'mulesoft_platform_integration_architect_exam__')
+  WHERE question_id LIKE 'plat_arch_202_exam__%';
+
+UPDATE scores
+  SET question_id = REPLACE(question_id, 'plat_arch_202_exam_en__', 'mulesoft_platform_integration_architect_exam_en__')
+  WHERE question_id LIKE 'plat_arch_202_exam_en__%';
+
+-- Step 6: Delete old exam rows
+DELETE FROM exams WHERE id IN (
+  'mule_dev_201_exam',
+  'mule_dev_201_exam_en',
+  'plat_arch_202_exam',
+  'plat_arch_202_exam_en'
+);
+
+-- Step 7: Fix display names for remaining exams (JA/EN separately)
+UPDATE exams SET name = 'Salesforce 認定 Experience Cloud コンサルタント'                    WHERE id = 'experience_cloud_consultant_exam';
+UPDATE exams SET name = 'Salesforce Certified Experience Cloud Consultant'                  WHERE id = 'experience_cloud_consultant_exam_en';
+UPDATE exams SET name = 'Salesforce 認定 Platform Identity and Access Management アーキテクト' WHERE id = 'platform_iam_architect_exam';
+UPDATE exams SET name = 'Salesforce Certified Platform Identity and Access Management Architect' WHERE id = 'platform_iam_architect_exam_en';
+UPDATE exams SET name = 'Salesforce 認定 User Experience (UX) デザイナー'                    WHERE id = 'ux_designer_exam';
+UPDATE exams SET name = 'Salesforce Certified Platform User Experience Designer'            WHERE id = 'ux_designer_exam_en';
+UPDATE exams SET name = 'Salesforce 認定 Service Cloud コンサルタント'                       WHERE id = 'service_cloud_consultant_exam';
+UPDATE exams SET name = 'Salesforce Certified Service Cloud Consultant'                     WHERE id = 'service_cloud_consultant_exam_en';

--- a/scripts/seed-d1.ts
+++ b/scripts/seed-d1.ts
@@ -19,12 +19,18 @@ const CSV_DIR = path.join(process.cwd(), "..");
 const SQL_OUT = path.join(process.cwd(), "scripts", "_seed.sql");
 
 const EXAM_NAMES: Record<string, string> = {
-  experience_cloud_consultant_exam: "Experience Cloud Consultant",
-  mule_dev_201_exam: "MuleSoft Developer I (DEV201)",
-  plat_arch_202_exam: "Platform App Builder / Architect 202",
-  platform_iam_architect_exam: "Platform Identity & Access Mgmt Architect",
-  service_cloud_consultant_exam: "Service Cloud Consultant",
-  ux_designer_exam: "UX Designer",
+  experience_cloud_consultant_exam:                "Salesforce 認定 Experience Cloud コンサルタント",
+  experience_cloud_consultant_exam_en:             "Salesforce Certified Experience Cloud Consultant",
+  mulesoft_developer_exam:                         "Salesforce 認定 MuleSoft デベロッパー",
+  mulesoft_developer_exam_en:                      "Salesforce Certified MuleSoft Developer",
+  mulesoft_platform_integration_architect_exam:    "Salesforce 認定 MuleSoft Platform Integration アーキテクト",
+  mulesoft_platform_integration_architect_exam_en: "Salesforce Certified MuleSoft Platform Integration Architect",
+  platform_iam_architect_exam:                     "Salesforce 認定 Platform Identity and Access Management アーキテクト",
+  platform_iam_architect_exam_en:                  "Salesforce Certified Platform Identity and Access Management Architect",
+  service_cloud_consultant_exam:                   "Salesforce 認定 Service Cloud コンサルタント",
+  service_cloud_consultant_exam_en:                "Salesforce Certified Service Cloud Consultant",
+  ux_designer_exam:                                "Salesforce 認定 User Experience (UX) デザイナー",
+  ux_designer_exam_en:                             "Salesforce Certified Platform User Experience Designer",
 };
 
 interface Choice { label: string; text: string; }
@@ -66,8 +72,7 @@ const csvFiles = fs.readdirSync(CSV_DIR).filter((f) => f.endsWith(".csv"));
 
 for (const file of csvFiles) {
   const examId = file.replace(".csv", "");
-  const baseName = examId.endsWith("_en") ? examId.slice(0, -3) : examId;
-  const name = EXAM_NAMES[baseName] ?? baseName;
+  const name = EXAM_NAMES[examId] ?? examId;
 
   let records: Record<string, string>[];
   try {


### PR DESCRIPTION
## Summary

- Add D1 migration 0006: rename `mule_dev_201_exam` → `mulesoft_developer_exam` and `plat_arch_202_exam` → `mulesoft_platform_integration_architect_exam`
- Migrate all related `questions`, `question_history`, `scores` IDs
- Fix display names for all exams to full official Salesforce names (JA: `Salesforce 認定 ...`, EN: `Salesforce Certified ...`)
- Update `scripts/seed-d1.ts` EXAM_NAMES with new keys and official full names

## Post-merge: apply D1 migration

After merging, run:
```
npx wrangler d1 execute quiz-db --remote --file=migrations/0006_rename_exam_ids.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)