### PR TITLE
feat: first-time onboarding guide

### DIFF
--- a/components/OnboardingGuide.tsx
+++ b/components/OnboardingGuide.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X, Upload, BookOpen, Settings } from "lucide-react";
+import { useSettings } from "@/lib/settings-context";
+
+const STORAGE_KEY = "onboarding-done";
+
+const STEP_ICONS = [Upload, BookOpen, Settings];
+
+export default function OnboardingGuide() {
+  const { t } = useSettings();
+  const [visible, setVisible] = useState(false);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        setVisible(true);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  function dismiss() {
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // ignore
+    }
+    setVisible(false);
+  }
+
+  function next() {
+    if (step < 2) {
+      setStep(step + 1);
+    } else {
+      dismiss();
+    }
+  }
+
+  if (!visible) return null;
+
+  const steps = [
+    { title: t("onboardingStep1Title"), desc: t("onboardingStep1Desc") },
+    { title: t("onboardingStep2Title"), desc: t("onboardingStep2Desc") },
+    { title: t("onboardingStep3Title"), desc: t("onboardingStep3Desc") },
+  ];
+
+  const Icon = STEP_ICONS[step];
+  const isLast = step === 2;
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-end justify-center pb-8 px-4 pointer-events-none">
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/20 pointer-events-auto"
+        onClick={dismiss}
+      />
+
+      {/* Bubble */}
+      <div className="relative pointer-events-auto w-full max-w-sm">
+        {/* Tail pointing down */}
+        <div className="absolute bottom-[-8px] left-1/2 -translate-x-1/2 w-4 h-4 bg-white rotate-45 border-b border-r border-gray-200 shadow-sm" />
+
+        <div className="bg-white rounded-2xl border border-gray-200 shadow-xl p-5">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+              {t("onboardingTitle")}
+            </p>
+            <button
+              onClick={dismiss}
+              className="text-gray-300 hover:text-gray-500 transition-colors"
+            >
+              <X size={14} />
+            </button>
+          </div>
+
+          {/* Step content */}
+          <div className="flex gap-3 items-start mb-5">
+            <div className="shrink-0 w-9 h-9 rounded-xl bg-blue-50 flex items-center justify-center">
+              <Icon size={16} className="text-blue-500" strokeWidth={1.5} />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-gray-800 mb-1">
+                {steps[step].title}
+              </p>
+              <p className="text-xs text-gray-500 leading-relaxed">
+                {steps[step].desc}
+              </p>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between">
+            {/* Dots */}
+            <div className="flex gap-1.5">
+              {steps.map((_, i) => (
+                <div
+                  key={i}
+                  className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                    i === step ? "bg-blue-500" : "bg-gray-200"
+                  }`}
+                />
+              ))}
+            </div>
+
+            <button
+              onClick={next}
+              className={`text-xs font-semibold px-4 py-2 rounded-lg transition-colors ${
+                isLast
+                  ? "bg-blue-500 text-white hover:bg-blue-600"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              {isLast ? t("onboardingDone") : t("onboardingNext")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -30,7 +30,16 @@ export type TranslationKey =
   | "aiRefineQuestion"
   | "aiRefineChoices"
   | "aiRefineChanges"
-  | "aiRefineNoChanges";
+  | "aiRefineNoChanges"
+  | "onboardingTitle"
+  | "onboardingStep1Title"
+  | "onboardingStep1Desc"
+  | "onboardingStep2Title"
+  | "onboardingStep2Desc"
+  | "onboardingStep3Title"
+  | "onboardingStep3Desc"
+  | "onboardingNext"
+  | "onboardingDone";
 
 const translations: Record<Locale, Record<TranslationKey, string>> = {
   en: {
@@ -64,6 +73,15 @@ const translations: Record<Locale, Record<TranslationKey, string>> = {
     aiRefineChoices: "Choices",
     aiRefineChanges: "Changes",
     aiRefineNoChanges: "No changes suggested",
+    onboardingTitle: "Welcome to Quiz",
+    onboardingStep1Title: "Add an exam",
+    onboardingStep1Desc: "Click the Add card or drag & drop a CSV file to load your first exam.",
+    onboardingStep2Title: "Start practicing",
+    onboardingStep2Desc: "Tap any exam card to begin. Wrong answers are tracked so you can focus on what matters.",
+    onboardingStep3Title: "Customize",
+    onboardingStep3Desc: "Open Settings to change the display language or configure the AI explanation prompt.",
+    onboardingNext: "Next",
+    onboardingDone: "Got it",
   },
   ja: {
     settings: "設定",
@@ -96,6 +114,15 @@ const translations: Record<Locale, Record<TranslationKey, string>> = {
     aiRefineChoices: "選択肢",
     aiRefineChanges: "変更箇所",
     aiRefineNoChanges: "修正箇所なし",
+    onboardingTitle: "Quizへようこそ",
+    onboardingStep1Title: "試験を追加する",
+    onboardingStep1Desc: "「Add」カードをクリックするか、CSVファイルをドラッグ＆ドロップして試験を読み込みましょう。",
+    onboardingStep2Title: "練習を始める",
+    onboardingStep2Desc: "試験カードをタップしてスタート。不正解の問題は記録され、苦手克服に集中できます。",
+    onboardingStep3Title: "カスタマイズ",
+    onboardingStep3Desc: "設定を開いて表示言語の変更やAI解説プロンプトの設定ができます。",
+    onboardingNext: "次へ",
+    onboardingDone: "はじめる",
   },
   zh: {
     settings: "设置",
@@ -128,6 +155,15 @@ const translations: Record<Locale, Record<TranslationKey, string>> = {
     aiRefineChoices: "选项",
     aiRefineChanges: "修改内容",
     aiRefineNoChanges: "无修改建议",
+    onboardingTitle: "欢迎使用 Quiz",
+    onboardingStep1Title: "添加考试",
+    onboardingStep1Desc: "点击「Add」卡片或拖放 CSV 文件来加载你的第一个考试。",
+    onboardingStep2Title: "开始练习",
+    onboardingStep2Desc: "点击任意考试卡片即可开始。答错的题目会被记录，方便你专项突破。",
+    onboardingStep3Title: "个性化设置",
+    onboardingStep3Desc: "打开设置可以更改显示语言或配置 AI 解释提示词。",
+    onboardingNext: "下一步",
+    onboardingDone: "开始吧",
   },
   ko: {
     settings: "설정",
@@ -160,6 +196,15 @@ const translations: Record<Locale, Record<TranslationKey, string>> = {
     aiRefineChoices: "선택지",
     aiRefineChanges: "변경 사항",
     aiRefineNoChanges: "수정 사항 없음",
+    onboardingTitle: "Quiz에 오신 것을 환영합니다",
+    onboardingStep1Title: "시험 추가",
+    onboardingStep1Desc: "「Add」카드를 클릭하거나 CSV 파일을 드래그 & 드롭하여 시험을 불러오세요.",
+    onboardingStep2Title: "연습 시작",
+    onboardingStep2Desc: "시험 카드를 탭하여 시작하세요. 틀린 문제는 기록되어 취약 부분에 집중할 수 있습니다.",
+    onboardingStep3Title: "커스터마이즈",
+    onboardingStep3Desc: "설정을 열어 표시 언어를 변경하거나 AI 해설 프롬프트를 설정할 수 있습니다.",
+    onboardingNext: "다음",
+    onboardingDone: "시작하기",
   },
 };
 


### PR DESCRIPTION
## Summary
- First-time visitors see a 3-step speech bubble guide on the exam list page
- Detection via `localStorage` (`onboarding-done` key) — shows only once
- Content served in the user's selected language (en/ja/zh/ko)

## Components
- `components/OnboardingGuide.tsx` — new step-by-step bubble with backdrop, step dots, and dismiss
- `lib/i18n.ts` — 9 new translation keys per locale (`onboardingTitle`, `onboardingStep1-3Title/Desc`, `onboardingNext`, `onboardingDone`)
- `components/ExamListClient.tsx` — mounts `<OnboardingGuide />`

## Test plan
- [ ] Visit the app in a fresh browser (or clear `onboarding-done` from localStorage) — guide appears
- [ ] Step through all 3 steps, verify "Got it" dismisses and sets flag
- [ ] Reload — guide does NOT reappear
- [ ] Change language in Settings, clear flag, revisit — guide shown in new language

🤖 Generated with [Claude Code](https://claude.com/claude-code)