### PR TITLE
fix: unify answer choice labels from numbers to letters (A/B/C/D)

### DIFF
--- a/components/AnswersClient.tsx
+++ b/components/AnswersClient.tsx
@@ -281,7 +281,7 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
                   <span className={`shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-md text-xs lg:text-sm font-bold flex items-center justify-center mt-0.5 ${
                     isAnswer ? "bg-emerald-500 text-white" : "bg-gray-100 text-gray-400"
                   }`}>
-                    {q.choices.indexOf(c) + 1}
+                    {c.label}
                   </span>
                   <span className={`text-sm lg:text-base leading-snug pt-0.5 whitespace-pre-wrap ${
                     isAnswer ? "text-emerald-900 font-medium" : "text-gray-500"

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -356,8 +356,8 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
         }
         return;
       }
-      const num = parseInt(e.key);
-      if (!isNaN(num) && num >= 1 && num <= labels.length) { handleToggle(labels[num - 1]); return; }
+      const letter = e.key.toUpperCase();
+      if (labels.includes(letter)) { handleToggle(letter); return; }
       if (e.key === "Enter")      { submitted ? goNext() : handleSubmit(); }
       if (e.key === "ArrowRight") goNext();
       if (e.key === "ArrowLeft")  goPrev();
@@ -495,7 +495,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
                             {q.choices.map((c, i) => (
                               <div key={c.label} className="border rounded-xl px-4 py-3 lg:px-5 lg:py-4 border-gray-100 bg-gray-50">
                                 <div className="flex items-start gap-3">
-                                  <span className="shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-lg border border-gray-200 bg-white text-xs lg:text-sm font-bold flex items-center justify-center text-gray-400">{i + 1}</span>
+                                  <span className="shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-lg border border-gray-200 bg-white text-xs lg:text-sm font-bold flex items-center justify-center text-gray-400">{c.label}</span>
                                   <span className="text-sm lg:text-base leading-relaxed pt-0.5 whitespace-pre-wrap text-gray-600">{c.text}</span>
                                 </div>
                               </div>
@@ -564,7 +564,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
                           <div className={`flex items-center gap-2 ${isCorrect ? "text-emerald-600" : "text-rose-600"}`}>
                             {isCorrect
                               ? <><CheckCircle2 size={17} strokeWidth={2.5} />{streak > 1 && <span className="text-xs text-emerald-400 ml-1">{streak}</span>}</>
-                              : <><XCircle size={17} strokeWidth={2.5} /><span className="text-xs text-gray-400 ml-1">{q.answers.map(a => q.choices.findIndex(c => c.label === a) + 1).join(", ")}</span></>
+                              : <><XCircle size={17} strokeWidth={2.5} /><span className="text-xs text-gray-400 ml-1">{q.answers.join(", ")}</span></>
                             }
                           </div>
                           <button

--- a/components/QuizQuestion.tsx
+++ b/components/QuizQuestion.tsx
@@ -86,7 +86,7 @@ export default function QuizQuestion({
             >
               <div className="flex items-start gap-3">
                 <span className={`shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-lg border text-xs lg:text-sm font-bold flex items-center justify-center transition-all ${badge}`}>
-                  {i + 1}
+                  {choice.label}
                 </span>
                 <span className={`text-sm lg:text-base leading-relaxed pt-0.5 whitespace-pre-wrap ${textColor}`}>
                   {choice.text}

--- a/components/ReviewReveal.tsx
+++ b/components/ReviewReveal.tsx
@@ -29,7 +29,7 @@ export default function ReviewReveal({ question, onNext, isLast, onAiExplain }: 
             .map((c) => (
               <div key={c.label} className="flex items-start gap-3 px-4 py-3 rounded-xl bg-emerald-50 border border-emerald-200">
                 <span className="shrink-0 w-6 h-6 rounded-md bg-emerald-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">
-                  {question.choices.findIndex(ch => ch.label === c.label) + 1}
+                  {c.label}
                 </span>
                 <span className="text-sm text-emerald-900 leading-snug">{c.text}</span>
               </div>


### PR DESCRIPTION
## Summary
- Choice badges now display A/B/C/D instead of 1/2/3/4 across all components
- Keyboard shortcuts updated: press A/B/C/D to select options (was 1/2/3/4)
- Affected: QuizQuestion, QuizClient (review panel + wrong-answer hint + keyboard handler), AnswersClient, ReviewReveal

## Test plan
- [ ] Quiz mode: choices show A/B/C/D badges
- [ ] Press A/B/C/D keys to select options
- [ ] Wrong answer hint shows letters (e.g. "A, C")
- [ ] Answer sheet: choice badges show A/B/C/D
- [ ] Review mode reveal: correct answers show A/B/C/D

🤖 Generated with [Claude Code](https://claude.com/claude-code)