### PR TITLE
feat: answer reveal modal, profile charts, keyboard hint toast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -186,3 +186,21 @@ body {
 .card-back {
   transform: rotateY(180deg);
 }
+
+/* ── Answer reveal modal ── */
+@keyframes modal-slide-up {
+  from { opacity: 0; transform: translateY(16px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+.modal-slide-up {
+  animation: modal-slide-up 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+/* ── Keyboard hint toast ── */
+@keyframes toast-slide-in-left {
+  from { opacity: 0; transform: translateX(-12px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.toast-slide-in-left {
+  animation: toast-slide-in-left 0.22s ease-out both;
+}

--- a/components/AnswerRevealModal.tsx
+++ b/components/AnswerRevealModal.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect } from "react";
+import { CheckCircle2, XCircle, ChevronRight, Sparkles } from "lucide-react";
+import type { Question } from "@/lib/types";
+
+interface Props {
+  question: Question;
+  isCorrect: boolean;
+  isLast: boolean;
+  onNext: () => void;
+  onAiExplain: () => void;
+}
+
+export default function AnswerRevealModal({ question, isCorrect, isLast, onNext, onAiExplain }: Props) {
+  // Keyboard: Escape / N / Enter → next
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "n" || e.key === "N" || e.key === "Enter") {
+        e.preventDefault();
+        onNext();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onNext]);
+
+  const correctChoices = question.choices.filter((c) => question.answers.includes(c.label));
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center sm:p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+        onClick={onNext}
+      />
+
+      {/* Modal card — centered on sm+, bottom-sheet on mobile */}
+      <div className="
+        modal-slide-up
+        relative bg-white w-full max-w-lg
+        rounded-t-2xl sm:rounded-2xl
+        shadow-2xl
+        flex flex-col
+        max-h-[85vh]
+        mt-auto sm:mt-0
+      ">
+        {/* Header */}
+        <div className={`shrink-0 flex items-center gap-3 px-6 pt-5 pb-4 border-b border-gray-100`}>
+          <div className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${isCorrect ? "bg-emerald-100" : "bg-rose-100"}`}>
+            {isCorrect
+              ? <CheckCircle2 size={22} className="text-emerald-500" strokeWidth={2.5} />
+              : <XCircle size={22} className="text-rose-500" strokeWidth={2.5} />
+            }
+          </div>
+          <div>
+            <p className={`font-bold text-lg leading-none ${isCorrect ? "text-emerald-600" : "text-rose-600"}`}>
+              {isCorrect ? "Correct!" : "Incorrect"}
+            </p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              {isCorrect
+                ? "Great job!"
+                : `Correct: ${question.answers.join(", ")}`
+              }
+            </p>
+          </div>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4 min-h-0">
+          {/* Correct answers */}
+          <div>
+            <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">Correct Answer</p>
+            <div className="flex flex-col gap-2">
+              {correctChoices.map((c) => (
+                <div key={c.label} className="flex items-start gap-3 px-4 py-3 rounded-xl bg-emerald-50 border border-emerald-200">
+                  <span className="shrink-0 w-6 h-6 rounded-md bg-emerald-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">
+                    {c.label}
+                  </span>
+                  <span className="text-sm text-emerald-900 leading-snug">{c.text}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Explanation */}
+          {question.explanation && (
+            <div>
+              <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">Explanation</p>
+              <p className="text-sm leading-relaxed text-gray-700 whitespace-pre-wrap">{question.explanation}</p>
+            </div>
+          )}
+
+          {question.source && (
+            <p className="text-xs text-gray-300">Source: {question.source}</p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 flex items-center justify-between gap-3 px-6 py-4 border-t border-gray-100">
+          <button
+            onClick={onAiExplain}
+            className="flex items-center gap-1.5 px-3 py-2 border border-gray-200 rounded-lg text-xs font-medium text-gray-500 hover:text-violet-500 hover:border-violet-200 transition-colors"
+          >
+            <Sparkles size={13} />
+            AI Explain
+          </button>
+          <button
+            onClick={onNext}
+            autoFocus
+            className="flex items-center gap-1.5 px-5 py-2.5 bg-gray-900 text-white text-sm font-semibold rounded-xl hover:bg-gray-700 transition-colors"
+          >
+            {isLast ? "Finish" : <><ChevronRight size={15} /> Next</>}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/CategoryChart.tsx
+++ b/components/CategoryChart.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip,
+  ResponsiveContainer, Cell,
+} from "recharts";
+import type { CategoryStat } from "@/lib/types";
+
+interface Props {
+  stats: CategoryStat[];
+}
+
+function barColor(pct: number) {
+  if (pct >= 80) return "#22c55e";
+  if (pct >= 60) return "#f59e0b";
+  return "#f43f5e";
+}
+
+export default function CategoryChart({ stats }: Props) {
+  const data = stats
+    .filter((c) => c.attempted > 0)
+    .map((c) => ({
+      name: c.category ?? "Uncategorized",
+      pct: Math.round((c.correct / c.total) * 100),
+    }))
+    .sort((a, b) => a.pct - b.pct);
+
+  if (data.length === 0) return null;
+
+  const height = Math.max(80, data.length * 32);
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{ top: 0, right: 40, bottom: 0, left: 4 }}
+      >
+        <XAxis
+          type="number"
+          domain={[0, 100]}
+          tick={{ fontSize: 9, fill: "#9ca3af" }}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(v) => `${v}%`}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={130}
+          tick={{ fontSize: 10, fill: "#6b7280" }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          formatter={(v) => [`${v}%`, "Accuracy"]}
+          contentStyle={{ fontSize: 11, borderRadius: 8, border: "1px solid #e5e7eb", padding: "4px 10px" }}
+        />
+        <Bar dataKey="pct" radius={[0, 4, 4, 0]} barSize={14} label={{ position: "right", fontSize: 10, fill: "#6b7280", formatter: (v: unknown) => `${v}%` }}>
+          {data.map((entry) => (
+            <Cell key={entry.name} fill={barColor(entry.pct)} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/components/ExamTrendChart.tsx
+++ b/components/ExamTrendChart.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip,
+  ResponsiveContainer, ReferenceLine,
+} from "recharts";
+import type { ExamSnapshot } from "@/lib/types";
+
+interface Props {
+  snapshots: ExamSnapshot[];
+}
+
+export default function ExamTrendChart({ snapshots }: Props) {
+  const data = snapshots.slice(-30).map((s) => ({
+    label: new Date(s.ts).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+    accuracy: s.accuracy,
+  }));
+
+  if (data.length === 0) {
+    return (
+      <p className="text-xs text-gray-300 py-4 text-center">
+        No history yet — answer some questions to see your trend
+      </p>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={110}>
+      <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: -28 }}>
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 9, fill: "#9ca3af" }}
+          tickLine={false}
+          axisLine={false}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          domain={[0, 100]}
+          tick={{ fontSize: 9, fill: "#9ca3af" }}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(v) => `${v}%`}
+        />
+        <Tooltip
+          formatter={(v) => [`${v}%`, "Accuracy"]}
+          contentStyle={{ fontSize: 11, borderRadius: 8, border: "1px solid #e5e7eb", padding: "4px 10px" }}
+          labelStyle={{ color: "#6b7280", fontSize: 10 }}
+        />
+        <ReferenceLine y={80} stroke="#d1fae5" strokeDasharray="3 3" />
+        <Line
+          type="monotone"
+          dataKey="accuracy"
+          stroke="#7c3aed"
+          strokeWidth={2}
+          dot={{ r: 2.5, fill: "#7c3aed", strokeWidth: 0 }}
+          activeDot={{ r: 4, fill: "#7c3aed" }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/components/KeyboardHintToast.tsx
+++ b/components/KeyboardHintToast.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+
+const STORAGE_KEY = "quiz-keyboard-hint-shown";
+
+export default function KeyboardHintToast() {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function dismiss() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    localStorage.setItem(STORAGE_KEY, "true");
+    setVisible(false);
+  }
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY)) return;
+    setVisible(true);
+    timerRef.current = setTimeout(dismiss, 8000);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    const handler = () => dismiss();
+    window.addEventListener("keydown", handler, { once: true });
+    return () => window.removeEventListener("keydown", handler);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-20 left-4 z-30 w-52 bg-white border border-gray-200 rounded-xl shadow-lg overflow-hidden toast-slide-in-left">
+      <div className="px-3 py-2.5 flex items-center justify-between border-b border-gray-100">
+        <span className="text-xs font-semibold text-gray-600">Keyboard Shortcuts</span>
+        <button
+          onClick={dismiss}
+          className="text-gray-300 hover:text-gray-500 transition-colors"
+          aria-label="Dismiss"
+        >
+          <X size={12} />
+        </button>
+      </div>
+      <div className="px-3 py-2.5">
+        <table className="w-full">
+          <tbody className="text-xs">
+            {([
+              ["1–9", "Choose answer"],
+              ["Enter", "Submit / Next"],
+              ["N", "Next question"],
+              ["← →", "Navigate"],
+            ] as const).map(([key, label]) => (
+              <tr key={key}>
+                <td className="py-0.5 pr-2">
+                  <kbd className="inline-block bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5 font-mono text-[10px] text-gray-600 whitespace-nowrap">
+                    {key}
+                  </kbd>
+                </td>
+                <td className="py-0.5 text-gray-500">{label}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="text-[10px] text-gray-300 text-center mt-2">Dismisses on first key press</p>
+      </div>
+    </div>
+  );
+}

--- a/components/ProfileClient.tsx
+++ b/components/ProfileClient.tsx
@@ -2,9 +2,12 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronRight, RotateCcw } from "lucide-react";
-import type { ExamMeta, QuizStats } from "@/lib/types";
+import { ChevronRight, RotateCcw, ChevronDown, Loader2 } from "lucide-react";
+import type { ExamMeta, QuizStats, CategoryStat, ExamSnapshot } from "@/lib/types";
 import PageHeader from "./PageHeader";
+import ExamTrendChart from "./ExamTrendChart";
+import CategoryChart from "./CategoryChart";
+import { getAllSnapshots } from "@/lib/snapshots";
 
 interface Props {
   exams: ExamMeta[];
@@ -31,6 +34,10 @@ interface ExamStats {
 export default function ProfileClient({ exams }: Props) {
   const router = useRouter();
   const [statsMap, setStatsMap] = useState<Record<string, ExamStats>>({});
+  const [expandedExamId, setExpandedExamId] = useState<string | null>(null);
+  const [categoryCache, setCategoryCache] = useState<Record<string, CategoryStat[]>>({});
+  const [categoryLoading, setCategoryLoading] = useState<Record<string, boolean>>({});
+  const [snapshotsMap, setSnapshotsMap] = useState<Record<string, ExamSnapshot[]>>({});
 
   useEffect(() => {
     const map: Record<string, ExamStats> = {};
@@ -47,7 +54,24 @@ export default function ProfileClient({ exams }: Props) {
       };
     }
     setStatsMap(map);
+    setSnapshotsMap(getAllSnapshots());
   }, [exams]);
+
+  function handleExamClick(examId: string) {
+    if (expandedExamId === examId) {
+      setExpandedExamId(null);
+      return;
+    }
+    setExpandedExamId(examId);
+    if (!categoryCache[examId]) {
+      setCategoryLoading((prev) => ({ ...prev, [examId]: true }));
+      fetch(`/api/category-stats?examId=${encodeURIComponent(examId)}`)
+        .then((r) => r.json() as Promise<CategoryStat[]>)
+        .then((data) => setCategoryCache((prev) => ({ ...prev, [examId]: data })))
+        .catch(() => {})
+        .finally(() => setCategoryLoading((prev) => ({ ...prev, [examId]: false })));
+    }
+  }
 
   // Aggregate stats
   const started = exams.filter((e) => (statsMap[e.id]?.answered ?? 0) > 0);
@@ -106,10 +130,16 @@ export default function ProfileClient({ exams }: Props) {
             {exams.map((exam) => {
               const s = statsMap[exam.id];
               const pct = s?.pct ?? null;
+              const isExpanded = expandedExamId === exam.id;
+              const snapshots = snapshotsMap[exam.id] ?? [];
+              const catStats = categoryCache[exam.id] ?? [];
+              const isLoadingCat = categoryLoading[exam.id] ?? false;
+              const hasCatData = catStats.some((c) => c.attempted > 0);
+
               return (
                 <div key={exam.id} className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
                   <button
-                    onClick={() => router.push(`/exam/${exam.id}`)}
+                    onClick={() => handleExamClick(exam.id)}
                     className="w-full text-left px-5 py-4 flex items-center gap-3 hover:bg-gray-50 transition-colors group"
                   >
                     <div className="flex-1 min-w-0">
@@ -145,9 +175,56 @@ export default function ProfileClient({ exams }: Props) {
                       ) : (
                         <span className="text-xs text-gray-300">Not started</span>
                       )}
-                      <ChevronRight size={14} className="text-gray-300 group-hover:text-gray-400 transition-colors" />
+                      <ChevronDown
+                        size={14}
+                        className={`text-gray-300 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+                      />
                     </div>
                   </button>
+
+                  {/* Expanded section */}
+                  {isExpanded && (
+                    <div className="border-t border-gray-100 px-5 py-4 space-y-5">
+
+                      {/* Score trend */}
+                      <div>
+                        <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                          Score Trend (last 30 sessions)
+                        </p>
+                        <ExamTrendChart snapshots={snapshots} />
+                      </div>
+
+                      {/* Category chart */}
+                      {isLoadingCat ? (
+                        <div className="flex items-center justify-center py-6">
+                          <Loader2 size={18} className="text-gray-300 animate-spin" />
+                        </div>
+                      ) : hasCatData ? (
+                        <div>
+                          <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                            Category Breakdown
+                          </p>
+                          <CategoryChart stats={catStats} />
+                        </div>
+                      ) : null}
+
+                      {/* Actions */}
+                      <div className="flex gap-2 pt-1">
+                        <button
+                          onClick={() => router.push(`/exam/${exam.id}`)}
+                          className="flex-1 py-2 text-sm font-medium border border-gray-200 rounded-xl text-gray-600 hover:bg-gray-50 transition-colors"
+                        >
+                          View Exam
+                        </button>
+                        <button
+                          onClick={() => router.push(`/quiz/${exam.id}?mode=quiz`)}
+                          className="flex-1 py-2 text-sm font-semibold bg-gray-900 text-white rounded-xl hover:bg-gray-700 transition-colors flex items-center justify-center gap-1"
+                        >
+                          Start Quiz <ChevronRight size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -15,7 +15,10 @@ import ReviewReveal from "./ReviewReveal";
 import QuestionEditModal from "./QuestionEditModal";
 import AiExplainPopup from "./AiExplainPopup";
 import AiRefinePopup from "./AiRefinePopup";
+import AnswerRevealModal from "./AnswerRevealModal";
+import KeyboardHintToast from "./KeyboardHintToast";
 import { useSettings } from "@/lib/settings-context";
+import { recordDailySnapshot } from "@/lib/snapshots";
 
 interface Props {
   questions: Question[];
@@ -114,6 +117,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     setStats((prev) => {
       const next = { ...prev, [String(questionId)]: correct ? 1 : 0 } as QuizStats;
       saveLocalStats(examId, next);
+      recordDailySnapshot(examId, next, questions.length);
       return next;
     });
     // Fire-and-forget sync to DB
@@ -344,6 +348,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     const handler = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       if (editingQuestion || aiPopupOpen || refinePopupOpen) return;
+      if (mode === "quiz" && submitted) return; // modal handles keys
 
       if (mode === "review") {
         if (!revealed) {
@@ -372,7 +377,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     ? `${(currentIndex / (filteredQuestions.length - 1)) * 100}%`
     : "0%";
 
-  const showRightPanel = mode === "quiz" && submitted && isCorrect === false;
+  const showAnswerModal = mode === "quiz" && submitted;
 
   if (filteredQuestions.length === 0) {
     return (
@@ -591,38 +596,6 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
           }
         </div>
 
-        {/* Right panel: explanation (quiz wrong answer) */}
-        <div className={`
-          flex flex-col overflow-hidden bg-white
-          ${!showRightPanel
-            ? "hidden"
-            : "shrink-0 w-full lg:w-[420px] border-t lg:border-t-0 lg:border-l border-gray-200 h-[40vh] lg:h-auto"
-          }
-        `}>
-          <div className="shrink-0 px-4 sm:px-8 pt-4 sm:pt-5 pb-3 border-b border-gray-100">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <XCircle size={15} className="text-rose-400 shrink-0" />
-                <span className="text-xs text-gray-500">Explanation</span>
-              </div>
-              <button
-                onClick={handleAiExplain}
-                className="text-gray-300 hover:text-violet-500 transition-colors"
-                title="AI Explain"
-              >
-                <Sparkles size={15} />
-              </button>
-            </div>
-          </div>
-          <div className="flex-1 overflow-y-auto px-4 sm:px-8 py-4">
-            {q.explanation ? (
-              <p className="text-sm leading-relaxed text-gray-700 whitespace-pre-wrap">{q.explanation}</p>
-            ) : (
-              <p className="text-sm text-gray-300">—</p>
-            )}
-            {q.source && <p className="text-xs text-gray-300 mt-4">Source: {q.source}</p>}
-          </div>
-        </div>
       </div>
 
       {/* ── Footer ── */}
@@ -723,6 +696,20 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
           }}
         />
       )}
+
+      {/* Answer reveal modal */}
+      {showAnswerModal && (
+        <AnswerRevealModal
+          question={q}
+          isCorrect={isCorrect === true}
+          isLast={isLast}
+          onNext={goNext}
+          onAiExplain={handleAiExplain}
+        />
+      )}
+
+      {/* Keyboard hint toast (first quiz session only) */}
+      {mode === "quiz" && <KeyboardHintToast />}
     </div>
   );
 }

--- a/components/ReviewReveal.tsx
+++ b/components/ReviewReveal.tsx
@@ -18,8 +18,9 @@ export default function ReviewReveal({ question, onNext, isLast, onAiExplain }: 
         <div className="flex items-center justify-between mb-3">
           <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Answer</p>
           {onAiExplain && (
-            <button onClick={onAiExplain} className="text-gray-300 hover:text-violet-500 transition-colors" title="AI Explain">
-              <Sparkles size={12} />
+            <button onClick={onAiExplain} className="flex items-center gap-1.5 px-2.5 py-1 border border-gray-200 rounded-lg text-xs font-medium text-gray-400 hover:text-violet-500 hover:border-violet-200 transition-colors">
+              <Sparkles size={11} />
+              AI Explain
             </button>
           )}
         </div>

--- a/lib/snapshots.ts
+++ b/lib/snapshots.ts
@@ -1,0 +1,48 @@
+import type { ExamSnapshot, QuizStats } from "./types";
+
+const SNAPSHOTS_KEY = "quiz-snapshots";
+
+function loadAllSnapshots(): Record<string, ExamSnapshot[]> {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(localStorage.getItem(SNAPSHOTS_KEY) ?? "{}");
+  } catch { return {}; }
+}
+
+function saveAllSnapshots(data: Record<string, ExamSnapshot[]>) {
+  localStorage.setItem(SNAPSHOTS_KEY, JSON.stringify(data));
+}
+
+export function getExamSnapshots(examId: string): ExamSnapshot[] {
+  return loadAllSnapshots()[examId] ?? [];
+}
+
+export function getAllSnapshots(): Record<string, ExamSnapshot[]> {
+  return loadAllSnapshots();
+}
+
+export function recordDailySnapshot(
+  examId: string,
+  stats: QuizStats,
+  totalQuestions: number,
+) {
+  if (typeof window === "undefined") return;
+  const today = new Date().toDateString();
+  const all = loadAllSnapshots();
+  const list = all[examId] ?? [];
+
+  const correct = Object.values(stats).filter((v) => v === 1).length;
+  const accuracy = totalQuestions > 0 ? Math.round((correct / totalQuestions) * 100) : 0;
+  const snap: ExamSnapshot = { ts: Date.now(), correct, total: totalQuestions, accuracy };
+
+  const last = list[list.length - 1];
+  if (last && new Date(last.ts).toDateString() === today) {
+    list[list.length - 1] = snap; // overwrite today's entry
+  } else {
+    list.push(snap);
+    if (list.length > 60) list.splice(0, list.length - 60);
+  }
+
+  all[examId] = list;
+  saveAllSnapshots(all);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,6 +51,13 @@ export type QuizStat = 0 | 1;
 
 export type QuizStats = Record<string, QuizStat>; // key: String(question.id)
 
+export interface ExamSnapshot {
+  ts: number;       // Unix ms
+  correct: number;
+  total: number;
+  accuracy: number; // 0–100
+}
+
 export interface UserSettings {
   language: "en" | "ja" | "zh" | "ko";
   aiPrompt: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "^15.5.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "recharts": "^3.8.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -1686,6 +1687,42 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1734,6 +1771,18 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
       "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2091,6 +2140,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/diff": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
@@ -2124,7 +2236,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2145,6 +2257,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vercel/blob": {
@@ -3745,6 +3863,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
@@ -3882,7 +4009,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/csv-parse": {
@@ -3890,6 +4017,127 @@
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
       "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
@@ -3919,6 +4167,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/defu": {
@@ -4051,6 +4305,16 @@
       "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.15.18",
@@ -4461,6 +4725,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/events-intercept": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/events-intercept/-/events-intercept-2.0.0.tgz",
@@ -4870,12 +5140,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
@@ -6130,6 +6419,37 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6141,6 +6461,52 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reghex": {
@@ -6159,6 +6525,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6716,6 +7088,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -6982,6 +7360,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -7050,6 +7437,28 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "next": "^15.5.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.8.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- **Answer reveal modal**: Replaces right-panel explanation with a centered modal overlay (backdrop-blur). Shows for both correct and wrong answers. AI Explain button visible in footer. Dismiss with Enter/N/Escape or backdrop click. Bottom-sheet on mobile.
- **Profile page charts**: Accordion expand per exam shows score trend line chart (purple, last 30 sessions) and category breakdown bar chart. Daily snapshot recording in localStorage. Lazy-loads category stats via `/api/category-stats`.
- **Keyboard hint toast**: Floating card (bottom-left) on first ever quiz session listing keyboard shortcuts. Auto-dismisses after 8s or on first key press. Uses `localStorage` flag to never repeat.
- **ReviewReveal AI Explain**: Updated from icon-only to visible labeled button.

## Test plan

- [ ] Answer a question wrong → modal appears centered with blur background, not right panel
- [ ] Answer a question right → same modal shows with green header
- [ ] Press Enter/N/Escape → modal dismisses, next question loads
- [ ] Clear `quiz-keyboard-hint-shown` from localStorage → start quiz → toast appears bottom-left
- [ ] Profile page → click an exam card → expands with trend chart and category chart
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)