### PR TITLE
feat: session tracking, AI Refine edit mode, and settings navigation fix

### DIFF
--- a/app/api/scores/route.ts
+++ b/app/api/scores/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getScores, saveScore } from "@/lib/db";
+import { getScores, saveScore, addSessionAnswer } from "@/lib/db";
 import { getUserEmail } from "@/lib/user";
 
 export const runtime = "edge";
@@ -15,12 +15,23 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json() as { examId: string; questionId: number; correct: boolean };
+  const body = await req.json() as {
+    examId: string;
+    questionId: number;
+    correct: boolean;
+    sessionId?: string;
+    questionDbId?: string;
+  };
   if (!body.examId || body.questionId == null || body.correct == null) {
     return NextResponse.json({ error: "invalid body" }, { status: 400 });
   }
 
   const userEmail = await getUserEmail();
   await saveScore(userEmail, body.examId, body.questionId, body.correct);
+
+  if (body.sessionId && body.questionDbId) {
+    await addSessionAnswer(body.sessionId, body.questionDbId, body.correct);
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { completeSession } from "@/lib/db";
+
+export const runtime = "edge";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const body = await req.json() as { correctCount: number };
+  if (body.correctCount == null) {
+    return NextResponse.json({ error: "correctCount required" }, { status: 400 });
+  }
+  await completeSession(id, body.correctCount);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSession, getSessionsByExam } from "@/lib/db";
+import { getUserEmail } from "@/lib/user";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json() as {
+    sessionId: string;
+    examId: string;
+    mode: "quiz" | "review";
+    filter: "all" | "wrong";
+    questionCount: number;
+  };
+  if (!body.sessionId || !body.examId || !body.mode || !body.filter || body.questionCount == null) {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  }
+  const userEmail = await getUserEmail();
+  await createSession(userEmail, body.examId, body.mode, body.filter, body.questionCount, body.sessionId);
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET(req: NextRequest) {
+  const examId = req.nextUrl.searchParams.get("examId");
+  if (!examId) return NextResponse.json({ error: "examId required" }, { status: 400 });
+  const userEmail = await getUserEmail();
+  const sessions = await getSessionsByExam(userEmail, examId);
+  return NextResponse.json(sessions);
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { Check, Sparkles, Wand2, BrainCircuit, RefreshCw } from "lucide-react";
 import { useSettings } from "@/lib/settings-context";
 import PageHeader from "@/components/PageHeader";
@@ -13,7 +14,11 @@ const LANGUAGES: { value: Locale; label: string; native: string }[] = [
   { value: "ko", label: "Korean", native: "한국어" },
 ];
 
-export default function SettingsPage() {
+function SettingsInner() {
+  const searchParams = useSearchParams();
+  const raw = searchParams.get("returnTo") ?? "/";
+  const returnTo = raw.startsWith("/") ? raw : "/";
+
   const { settings, updateSettings, t } = useSettings();
   const [language, setLanguage] = useState<Locale>(settings.language);
   const [aiPrompt, setAiPrompt] = useState(settings.aiPrompt);
@@ -69,7 +74,7 @@ export default function SettingsPage() {
 
   return (
     <div className="min-h-screen bg-[#f8f9fb] flex flex-col">
-      <PageHeader back={{ href: "/" }} title={t("settings")} />
+      <PageHeader back={{ href: returnTo }} title={t("settings")} hideSettingsIcon />
       <main className="flex-1 px-4 sm:px-8 py-8 max-w-xl mx-auto w-full space-y-8">
 
         {/* Language */}
@@ -183,5 +188,13 @@ export default function SettingsPage() {
         </button>
       </main>
     </div>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <Suspense>
+      <SettingsInner />
+    </Suspense>
   );
 }

--- a/components/AiRefinePopup.tsx
+++ b/components/AiRefinePopup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Loader2, Wand2, X, CheckCheck } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Loader2, Wand2, X, CheckCheck, Pencil } from "lucide-react";
 import { diffWords } from "diff";
 import type { AiRefineResponse } from "@/app/api/ai/refine/route";
 import type { Choice } from "@/lib/types";
@@ -13,7 +14,7 @@ interface Props {
   result: AiRefineResponse | null;
   error: string | null;
   adopting: boolean;
-  onAdopt: () => Promise<void>;
+  onAdopt: (edited: { question: string; choices: Choice[] }) => Promise<void>;
   onDismiss: () => void;
 }
 
@@ -65,9 +66,22 @@ export default function AiRefinePopup({
 }: Props) {
   const { t } = useSettings();
 
+  const [editMode, setEditMode] = useState(false);
+  const [editedQuestion, setEditedQuestion] = useState("");
+  const [editedChoices, setEditedChoices] = useState<Choice[]>([]);
+
+  // Reset edit state when a new result arrives
+  useEffect(() => {
+    if (result) {
+      setEditedQuestion(result.question);
+      setEditedChoices(result.choices.map((c) => ({ ...c })));
+      setEditMode(false);
+    }
+  }, [result]);
+
   const questionChanged = result ? hasAnyChange(originalQuestion, result.question) : false;
   const changedChoices = result
-    ? result.choices.filter((c, i) => {
+    ? result.choices.filter((c) => {
         const orig = originalChoices.find((o) => o.label === c.label);
         return orig ? hasAnyChange(orig.text, c.text) : false;
       })
@@ -82,12 +96,27 @@ export default function AiRefinePopup({
           <Wand2 size={13} className="text-amber-500" />
           <span className="text-sm font-semibold text-gray-800">{t("refine")}</span>
         </div>
-        <button
-          onClick={onDismiss}
-          className="p-1 rounded-lg hover:bg-gray-100 text-gray-400 transition-colors"
-        >
-          <X size={13} />
-        </button>
+        <div className="flex items-center gap-1">
+          {result && hasChanges && (
+            <button
+              onClick={() => setEditMode((v) => !v)}
+              className={`p-1 rounded-lg transition-colors ${
+                editMode
+                  ? "bg-amber-100 text-amber-700"
+                  : "text-gray-400 hover:bg-gray-100"
+              }`}
+              title={editMode ? "View diff" : "Edit"}
+            >
+              <Pencil size={12} />
+            </button>
+          )}
+          <button
+            onClick={onDismiss}
+            className="p-1 rounded-lg hover:bg-gray-100 text-gray-400 transition-colors"
+          >
+            <X size={13} />
+          </button>
+        </div>
       </div>
 
       {/* Body */}
@@ -108,49 +137,94 @@ export default function AiRefinePopup({
         )}
 
         {result && hasChanges && (
-          <>
-            {/* Question diff */}
-            {questionChanged && (
-              <div>
-                <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
-                  {t("aiRefineQuestion")}
-                </p>
-                <div className="bg-gray-50 rounded-xl p-3 leading-relaxed">
-                  <DiffText original={originalQuestion} refined={result.question} />
+          editMode ? (
+            /* Edit mode */
+            <div className="space-y-3">
+              {questionChanged && (
+                <div>
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
+                    {t("aiRefineQuestion")}
+                  </p>
+                  <textarea
+                    value={editedQuestion}
+                    onChange={(e) => setEditedQuestion(e.target.value)}
+                    rows={4}
+                    className="w-full rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-900 focus:outline-none focus:ring-2 focus:ring-amber-400 resize-none"
+                  />
                 </div>
-              </div>
-            )}
-
-            {/* Choices diff */}
-            {changedChoices.length > 0 && (
-              <div>
-                <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
-                  {t("aiRefineChoices")}
-                </p>
-                <div className="space-y-2">
-                  {changedChoices.map((refined) => {
-                    const orig = originalChoices.find((o) => o.label === refined.label)!;
-                    return (
-                      <div key={refined.label} className="bg-gray-50 rounded-xl p-3">
-                        <span className="text-[10px] font-bold text-gray-400 mr-2">{refined.label}.</span>
-                        <DiffText original={orig.text} refined={refined.text} />
-                      </div>
-                    );
-                  })}
+              )}
+              {changedChoices.length > 0 && (
+                <div>
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
+                    {t("aiRefineChoices")}
+                  </p>
+                  <div className="space-y-2">
+                    {editedChoices.map((c, idx) => {
+                      const isChanged = changedChoices.some((cc) => cc.label === c.label);
+                      if (!isChanged) return null;
+                      return (
+                        <div key={c.label} className="flex items-center gap-2">
+                          <span className="text-[10px] font-bold text-gray-400 shrink-0">{c.label}.</span>
+                          <input
+                            type="text"
+                            value={c.text}
+                            onChange={(e) =>
+                              setEditedChoices((prev) =>
+                                prev.map((ec, i) => i === idx ? { ...ec, text: e.target.value } : ec)
+                              )
+                            }
+                            className="flex-1 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-900 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
+          ) : (
+            /* Diff view */
+            <>
+              {questionChanged && (
+                <div>
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
+                    {t("aiRefineQuestion")}
+                  </p>
+                  <div className="bg-gray-50 rounded-xl p-3 leading-relaxed">
+                    <DiffText original={originalQuestion} refined={result.question} />
+                  </div>
+                </div>
+              )}
 
-            {/* Changes summary */}
-            {result.changesSummary && (
-              <div>
-                <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
-                  {t("aiRefineChanges")}
-                </p>
-                <p className="text-xs text-gray-500 leading-relaxed">{result.changesSummary}</p>
-              </div>
-            )}
-          </>
+              {changedChoices.length > 0 && (
+                <div>
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
+                    {t("aiRefineChoices")}
+                  </p>
+                  <div className="space-y-2">
+                    {changedChoices.map((refined) => {
+                      const orig = originalChoices.find((o) => o.label === refined.label)!;
+                      return (
+                        <div key={refined.label} className="bg-gray-50 rounded-xl p-3">
+                          <span className="text-[10px] font-bold text-gray-400 mr-2">{refined.label}.</span>
+                          <DiffText original={orig.text} refined={refined.text} />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {result.changesSummary && (
+                <div>
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
+                    {t("aiRefineChanges")}
+                  </p>
+                  <p className="text-xs text-gray-500 leading-relaxed">{result.changesSummary}</p>
+                </div>
+              )}
+            </>
+          )
         )}
       </div>
 
@@ -164,7 +238,7 @@ export default function AiRefinePopup({
             {t("dismiss")}
           </button>
           <button
-            onClick={onAdopt}
+            onClick={() => onAdopt({ question: editedQuestion, choices: editedChoices })}
             disabled={adopting || !hasChanges}
             className="flex-1 py-2 rounded-xl bg-amber-500 text-white text-sm font-semibold hover:bg-amber-600 disabled:opacity-40 transition-colors flex items-center justify-center gap-1.5"
           >

--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -7,9 +7,10 @@ interface Props {
   back?: { href: string; label?: string };
   title?: string;
   right?: React.ReactNode;
+  hideSettingsIcon?: boolean;
 }
 
-export default function PageHeader({ back, title, right }: Props) {
+export default function PageHeader({ back, title, right, hideSettingsIcon }: Props) {
   return (
     <header className="h-14 bg-white border-b border-gray-200 shrink-0 flex items-center px-4 sm:px-8">
       <div className="flex items-center gap-3 w-full">
@@ -31,13 +32,15 @@ export default function PageHeader({ back, title, right }: Props) {
         )}
         <div className="ml-auto flex items-center gap-2">
           {right}
-          <Link
-            href="/settings"
-            className="p-1.5 rounded-lg text-gray-300 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-            title="Settings"
-          >
-            <Settings size={14} />
-          </Link>
+          {!hideSettingsIcon && (
+            <Link
+              href="/settings"
+              className="p-1.5 rounded-lg text-gray-300 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+              title="Settings"
+            >
+              <Settings size={14} />
+            </Link>
+          )}
         </div>
       </div>
     </header>

--- a/components/ProfileClient.tsx
+++ b/components/ProfileClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronRight, RotateCcw, ChevronDown, Loader2 } from "lucide-react";
-import type { ExamMeta, QuizStats, CategoryStat, ExamSnapshot } from "@/lib/types";
+import type { ExamMeta, QuizStats, CategoryStat, ExamSnapshot, SessionRecord } from "@/lib/types";
 import PageHeader from "./PageHeader";
 import ExamTrendChart from "./ExamTrendChart";
 import CategoryChart from "./CategoryChart";
@@ -38,6 +38,7 @@ export default function ProfileClient({ exams }: Props) {
   const [categoryCache, setCategoryCache] = useState<Record<string, CategoryStat[]>>({});
   const [categoryLoading, setCategoryLoading] = useState<Record<string, boolean>>({});
   const [snapshotsMap, setSnapshotsMap] = useState<Record<string, ExamSnapshot[]>>({});
+  const [sessionCache, setSessionCache] = useState<Record<string, SessionRecord[]>>({});
 
   useEffect(() => {
     const map: Record<string, ExamStats> = {};
@@ -70,6 +71,12 @@ export default function ProfileClient({ exams }: Props) {
         .then((data) => setCategoryCache((prev) => ({ ...prev, [examId]: data })))
         .catch(() => {})
         .finally(() => setCategoryLoading((prev) => ({ ...prev, [examId]: false })));
+    }
+    if (!sessionCache[examId]) {
+      fetch(`/api/sessions?examId=${encodeURIComponent(examId)}`)
+        .then((r) => r.json() as Promise<SessionRecord[]>)
+        .then((data) => setSessionCache((prev) => ({ ...prev, [examId]: data })))
+        .catch(() => {});
     }
   }
 
@@ -134,6 +141,7 @@ export default function ProfileClient({ exams }: Props) {
               const snapshots = snapshotsMap[exam.id] ?? [];
               const catStats = categoryCache[exam.id] ?? [];
               const isLoadingCat = categoryLoading[exam.id] ?? false;
+              const sessions = sessionCache[exam.id] ?? [];
               const hasCatData = catStats.some((c) => c.attempted > 0);
 
               return (
@@ -207,6 +215,44 @@ export default function ProfileClient({ exams }: Props) {
                           <CategoryChart stats={catStats} />
                         </div>
                       ) : null}
+
+                      {/* Session history */}
+                      {sessions.length > 0 && (
+                        <div>
+                          <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                            Session History
+                          </p>
+                          <div className="space-y-1">
+                            {sessions.map((s) => {
+                              const pct = s.correctCount != null
+                                ? Math.round((s.correctCount / s.questionCount) * 100)
+                                : null;
+                              return (
+                                <div key={s.id} className="flex items-center justify-between text-xs py-1.5 px-3 bg-gray-50 rounded-xl">
+                                  <div className="flex items-center gap-2">
+                                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-gray-200 text-gray-500 font-medium uppercase">
+                                      {s.mode}
+                                    </span>
+                                    <span className="text-gray-400">
+                                      {new Date(s.startedAt + "Z").toLocaleDateString()}
+                                    </span>
+                                  </div>
+                                  <span className={`font-semibold tabular-nums ${
+                                    pct === null ? "text-gray-300"
+                                    : pct >= 80 ? "text-emerald-600"
+                                    : pct >= 60 ? "text-amber-500"
+                                    : "text-rose-500"
+                                  }`}>
+                                    {s.correctCount != null
+                                      ? `${s.correctCount}/${s.questionCount}`
+                                      : `—/${s.questionCount}`}
+                                  </span>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
 
                       {/* Actions */}
                       <div className="flex gap-2 pt-1">

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
@@ -75,9 +75,29 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const [refineError, setRefineError] = useState<string | null>(null);
   const [refineAdopting, setRefineAdopting] = useState(false);
 
+  const [sessionId] = useState<string>(() => crypto.randomUUID());
+  const [sessionCorrectCount, setSessionCorrectCount] = useState(0);
+  const sessionCompletedRef = useRef(false);
+
   const { settings } = useSettings();
 
   const backHref = `/exam/${examId}`;
+
+  // Create session on mount
+  useEffect(() => {
+    fetch("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+        examId,
+        mode,
+        filter: "all",
+        questionCount: initialQuestions.length,
+      }),
+    }).catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Load local stats then merge with DB stats (DB wins)
   useEffect(() => {
@@ -113,20 +133,21 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const overallRate = totalAnswered > 0 ? Math.round((totalCorrect / questions.length) * 100) : null;
   const wrongCount = questions.filter((q) => stats[String(q.id)] === 0).length;
 
-  const recordAnswer = useCallback((questionId: number, correct: boolean) => {
+  const recordAnswer = useCallback((questionId: number, correct: boolean, questionDbId: string) => {
     setStats((prev) => {
       const next = { ...prev, [String(questionId)]: correct ? 1 : 0 } as QuizStats;
       saveLocalStats(examId, next);
       recordDailySnapshot(examId, next, questions.length);
       return next;
     });
+    if (correct) setSessionCorrectCount((c) => c + 1);
     // Fire-and-forget sync to DB
     fetch("/api/scores", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ examId, questionId, correct }),
+      body: JSON.stringify({ examId, questionId, correct, sessionId, questionDbId }),
     }).catch(() => {});
-  }, [examId]);
+  }, [examId, sessionId]);
 
   const handleToggle = useCallback((label: string) => {
     if (submitted) return;
@@ -152,7 +173,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     const correct = q.answers.length === selected.size && q.answers.every((a) => selected.has(a));
     setIsCorrect(correct);
     setSubmitted(true);
-    recordAnswer(q.id, correct);
+    recordAnswer(q.id, correct, q.dbId);
     if (mode !== "review") {
       setStreak((prev) => correct ? prev + 1 : 0);
     }
@@ -168,33 +189,53 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     setCurrentIndex((i) => Math.max(i - 1, 0));
   }, []);
 
+  const doCompleteSession = useCallback(() => {
+    if (sessionCompletedRef.current) return;
+    sessionCompletedRef.current = true;
+    navigator.sendBeacon(
+      `/api/sessions/${sessionId}`,
+      new Blob(
+        [JSON.stringify({ correctCount: sessionCorrectCount })],
+        { type: "application/json" }
+      )
+    );
+  }, [sessionId, sessionCorrectCount]);
+
+  // Complete session on tab close / refresh
+  useEffect(() => {
+    window.addEventListener("beforeunload", doCompleteSession);
+    return () => window.removeEventListener("beforeunload", doCompleteSession);
+  }, [doCompleteSession]);
+
   const handleKnow = useCallback(() => {
     const q = filteredQuestions[currentIndex];
     if (!q) return;
-    recordAnswer(q.id, true);
+    recordAnswer(q.id, true, q.dbId);
     setStreak((prev) => prev + 1);
     if (currentIndex === filteredQuestions.length - 1) {
+      doCompleteSession();
       router.push(backHref);
     } else {
       goNext();
     }
-  }, [filteredQuestions, currentIndex, recordAnswer, goNext, router, backHref]);
+  }, [filteredQuestions, currentIndex, recordAnswer, goNext, router, backHref, doCompleteSession]);
 
   const handleDontKnow = useCallback(() => {
     const q = filteredQuestions[currentIndex];
     if (!q) return;
-    recordAnswer(q.id, false);
+    recordAnswer(q.id, false, q.dbId);
     setStreak(0);
     setRevealed(true);
   }, [filteredQuestions, currentIndex, recordAnswer]);
 
   const handleRevealNext = useCallback(() => {
     if (currentIndex === filteredQuestions.length - 1) {
+      doCompleteSession();
       router.push(backHref);
     } else {
       goNext();
     }
-  }, [currentIndex, filteredQuestions.length, goNext, router, backHref]);
+  }, [currentIndex, filteredQuestions.length, goNext, router, backHref, doCompleteSession]);
 
   const handleQuestionSave = useCallback((updated: Question) => {
     setQuestions((prev) => {
@@ -305,8 +346,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     }
   }, [filteredQuestions, currentIndex, settings.aiRefinePrompt]);
 
-  const handleRefineAdopt = useCallback(async () => {
-    if (!refineResult) return;
+  const handleRefineAdopt = useCallback(async (edited: { question: string; choices: typeof initialQuestions[0]["choices"] }) => {
     const q = filteredQuestions[currentIndex];
     if (!q) return;
     setRefineAdopting(true);
@@ -315,18 +355,18 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          question_text: refineResult.question,
-          options: refineResult.choices,
+          question_text: edited.question,
+          options: edited.choices,
           answers: q.answers,
           explanation: q.explanation,
-          change_reason: `AI refined: ${refineResult.changesSummary || "typo/grammar fix"}`,
+          change_reason: `AI refined: ${refineResult?.changesSummary || "typo/grammar fix"}`,
         }),
       });
       if (!res.ok) throw new Error("Update failed");
       setQuestions((prev) =>
         prev.map((pq) =>
           pq.dbId === q.dbId
-            ? { ...pq, question: refineResult.question, choices: refineResult.choices }
+            ? { ...pq, question: edited.question, choices: edited.choices }
             : pq
         )
       );
@@ -337,7 +377,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     } finally {
       setRefineAdopting(false);
     }
-  }, [refineResult, filteredQuestions, currentIndex]);
+  }, [filteredQuestions, currentIndex]);
 
   // Keyboard
   useEffect(() => {
@@ -391,9 +431,9 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
             Show all
           </button>
         )}
-        <Link href={backHref} className="text-sm text-gray-400 hover:text-gray-700 flex items-center gap-1.5">
+        <button onClick={() => { doCompleteSession(); router.push(backHref); }} className="text-sm text-gray-400 hover:text-gray-700 flex items-center gap-1.5">
           <ArrowLeft size={14} />
-        </Link>
+        </button>
       </div>
     );
   }
@@ -405,9 +445,12 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
       {/* ── Header ── */}
       <header className="shrink-0 flex items-center justify-between px-4 sm:px-6 h-12 border-b border-gray-200 bg-white">
         <div className="flex items-center gap-3 sm:gap-4 min-w-0">
-          <Link href={backHref} className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 transition-colors shrink-0">
+          <button
+            onClick={() => { doCompleteSession(); router.push(backHref); }}
+            className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 transition-colors shrink-0"
+          >
             <ArrowLeft size={14} />
-          </Link>
+          </button>
           <div className="flex items-center gap-1.5 text-xs text-gray-400 min-w-0">
             <ModeIcon size={13} strokeWidth={1.75} className="shrink-0" />
             <span className="truncate">{examName}</span>
@@ -440,7 +483,11 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
               <AlertCircle size={11} /> <span className="hidden sm:inline">Wrong</span> {wrongCount}
             </button>
           </div>
-          <Link href="/settings" className="p-1.5 rounded-lg text-gray-300 hover:text-gray-600 hover:bg-gray-100 transition-colors" title="Settings">
+          <Link
+            href={`/settings?returnTo=${encodeURIComponent(`/quiz/${examId}?mode=${mode}`)}`}
+            className="p-1.5 rounded-lg text-gray-300 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            title="Settings"
+          >
             <Settings size={13} />
           </Link>
         </div>

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,4 @@
-import type { CategoryStat, Choice, ExamMeta, Question, QuestionHistoryEntry, QuizStats } from "./types";
+import type { CategoryStat, Choice, ExamMeta, Question, QuestionHistoryEntry, QuizStats, SessionRecord } from "./types";
 import { getRequestContext } from "@cloudflare/next-on-pages";
 
 // Minimal D1 type stub – replaced by @cloudflare/workers-types after npm install
@@ -356,6 +356,88 @@ export async function saveScore(
     )
     .bind(userEmail, questionId, lastCorrect, correctDelta)
     .run();
+}
+
+// ── Sessions ───────────────────────────────────────────────────────────────
+
+export async function createSession(
+  userEmail: string,
+  examId: string,
+  mode: "quiz" | "review",
+  filter: "all" | "wrong",
+  questionCount: number,
+  sessionId: string
+): Promise<void> {
+  const db = getDB();
+  if (!db) return;
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO sessions (id, user_email, exam_id, mode, filter, started_at, question_count)
+       VALUES (?, ?, ?, ?, ?, datetime('now'), ?)`
+    )
+    .bind(sessionId, userEmail, examId, mode, filter, questionCount)
+    .run();
+}
+
+export async function completeSession(
+  sessionId: string,
+  correctCount: number
+): Promise<void> {
+  const db = getDB();
+  if (!db) return;
+  await db
+    .prepare(
+      `UPDATE sessions SET completed_at = datetime('now'), correct_count = ? WHERE id = ?`
+    )
+    .bind(correctCount, sessionId)
+    .run();
+}
+
+export async function addSessionAnswer(
+  sessionId: string,
+  questionId: string,
+  isCorrect: boolean
+): Promise<void> {
+  const db = getDB();
+  if (!db) return;
+  await db
+    .prepare(
+      `INSERT INTO session_answers (session_id, question_id, is_correct, answered_at)
+       VALUES (?, ?, ?, datetime('now'))`
+    )
+    .bind(sessionId, questionId, isCorrect ? 1 : 0)
+    .run();
+}
+
+export async function getSessionsByExam(
+  userEmail: string,
+  examId: string,
+  limit = 20
+): Promise<SessionRecord[]> {
+  const db = getDB();
+  if (!db) return [];
+  const result = await db
+    .prepare(
+      `SELECT id, user_email, exam_id, mode, filter, started_at, completed_at, question_count, correct_count
+       FROM sessions WHERE user_email = ? AND exam_id = ?
+       ORDER BY started_at DESC LIMIT ?`
+    )
+    .bind(userEmail, examId, limit)
+    .all<{
+      id: string; user_email: string; exam_id: string; mode: string; filter: string;
+      started_at: string; completed_at: string | null; question_count: number; correct_count: number | null;
+    }>();
+  return (result.results ?? []).map((row) => ({
+    id: row.id,
+    userEmail: row.user_email,
+    examId: row.exam_id,
+    mode: row.mode as "quiz" | "review",
+    filter: row.filter as "all" | "wrong",
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    questionCount: row.question_count,
+    correctCount: row.correct_count,
+  }));
 }
 
 // ── App settings ───────────────────────────────────────────────────────────

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -99,6 +99,18 @@ Respond ONLY with a JSON object (no markdown, no code fences) with exactly these
 - choices: array of corrected choices in the same order (identical to input if no errors found)
 - changesSummary: a brief human-readable summary of what was changed, or empty string if nothing changed`;
 
+export interface SessionRecord {
+  id: string;
+  userEmail: string;
+  examId: string;
+  mode: "quiz" | "review";
+  filter: "all" | "wrong";
+  startedAt: string;
+  completedAt: string | null;
+  questionCount: number;
+  correctCount: number | null;
+}
+
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   language: "en",
   aiPrompt: DEFAULT_EXPLAIN_PROMPT,


### PR DESCRIPTION
## Summary
- **Session tracking**: Each quiz/flashcard attempt creates a session in D1, records per-question results, and links to the user (email). Profile page now shows session history per exam.
- **AI Refine edit mode**: After AI Refine runs, users can click the pencil icon to edit the refined text before adopting it.
- **Settings navigation fix**: Navigating to Settings from the quiz screen now returns to the quiz screen (not home) when pressing back.

## DB Changes
- Migration `0007_sessions.sql`: adds `sessions` and `session_answers` tables
- **Production D1 migration must be applied after merge**

## Test plan
- [ ] Start a quiz, answer some questions, press back → check `/api/sessions` returns the session with `correct_count`
- [ ] Profile page → expand an exam → verify session history rows appear
- [ ] AI Refine → click pencil icon → edit text → Adopt → verify edited text is saved
- [ ] Quiz screen → Settings → back button → returns to quiz (not home)

🤖 Generated with [Claude Code](https://claude.com/claude-code)