### PR TITLE
fix: prevent answer modal instant dismiss on Enter key submit

### DIFF
--- a/components/AnswerRevealModal.tsx
+++ b/components/AnswerRevealModal.tsx
@@ -14,8 +14,11 @@ interface Props {
 
 export default function AnswerRevealModal({ question, isCorrect, isLast, onNext, onAiExplain }: Props) {
   // Keyboard: Escape / N / Enter → next
+  // 150ms guard prevents the same keydown that triggered Submit from instantly dismissing the modal
   useEffect(() => {
+    const ready = Date.now();
     const handler = (e: KeyboardEvent) => {
+      if (Date.now() - ready < 150) return;
       if (e.key === "Escape" || e.key === "n" || e.key === "N" || e.key === "Enter") {
         e.preventDefault();
         onNext();
@@ -107,7 +110,6 @@ export default function AnswerRevealModal({ question, isCorrect, isLast, onNext,
           </button>
           <button
             onClick={onNext}
-            autoFocus
             className="flex items-center gap-1.5 px-5 py-2.5 bg-gray-900 text-white text-sm font-semibold rounded-xl hover:bg-gray-700 transition-colors"
           >
             {isLast ? "Finish" : <><ChevronRight size={15} /> Next</>}


### PR DESCRIPTION
## Problem

After implementing AnswerRevealModal, submitting with the Enter key caused the modal to appear and instantly disappear.

## Root Cause

Two compounding issues:
1. **`autoFocus` on Next button** — when the modal mounts, the button immediately receives keyboard focus. The browser then fires the button's `onClick` from the active Enter keydown that triggered Submit, calling `onNext()` immediately.
2. **No mount guard on keydown listener** — the modal's keydown handler (via `useEffect`) could also catch rapidly repeated Enter presses right at mount time.

## Fix

- Remove `autoFocus` from the Next button (keyboard navigation still works via the `useEffect` listener)
- Add a 150ms guard: ignore any keydown events that arrive within 150ms of modal mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)