### PR TITLE
fix: raise AI popup z-index above answer reveal modal

### DIFF
--- a/components/AiExplainPopup.tsx
+++ b/components/AiExplainPopup.tsx
@@ -17,7 +17,7 @@ export default function AiExplainPopup({ loading, result, error, adopting, onAdo
   const { t } = useSettings();
 
   return (
-    <div className="fixed bottom-20 right-4 sm:right-8 z-40 w-80 sm:w-[22rem] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden">
+    <div className="fixed bottom-20 right-4 sm:right-8 z-60 w-80 sm:w-[22rem] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 bg-gradient-to-r from-violet-50 to-white shrink-0">
         <div className="flex items-center gap-2">

--- a/components/AiRefinePopup.tsx
+++ b/components/AiRefinePopup.tsx
@@ -89,7 +89,7 @@ export default function AiRefinePopup({
   const hasChanges = questionChanged || changedChoices.length > 0;
 
   return (
-    <div className="fixed bottom-20 right-4 sm:right-8 z-40 w-80 sm:w-[26rem] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden">
+    <div className="fixed bottom-20 right-4 sm:right-8 z-60 w-80 sm:w-[26rem] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 bg-gradient-to-r from-amber-50 to-white shrink-0">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- `AiExplainPopup` and `AiRefinePopup` had z-index `z-40`, while `AnswerRevealModal` was `z-50`
- This caused the AI popups to render behind the modal, making them invisible until the modal was closed
- Fix: raise both popup z-indexes to `z-60` so they appear on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)