### PR TITLE
fix: quiz last question finish button stuck

### DIFF
--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -754,7 +754,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
           question={q}
           isCorrect={isCorrect === true}
           isLast={isLast}
-          onNext={goNext}
+          onNext={handleRevealNext}
           onAiExplain={handleAiExplain}
         />
       )}


### PR DESCRIPTION
## Summary
- `AnswerRevealModal` の `onNext` に `goNext` が渡されていたため、最終問題で Finish ボタンを押してもモーダルが閉じずフリーズしていた
- `handleRevealNext` に変更することで、最終問題では `doCompleteSession()` + 画面遷移が正しく実行される

## Test plan
- [ ] quiz モードで最終問題まで進み、回答後に Finish ボタンを押す → 試験一覧に戻ることを確認
- [ ] Enter / Escape キーでも同様に動作することを確認
- [ ] 最終問題以外の Next は引き続き正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)