### PR TITLE
feat: show Salesforce grounding sources in AI Explain popup

### DIFF
--- a/app/api/ai/explain/route.ts
+++ b/app/api/ai/explain/route.ts
@@ -8,11 +8,24 @@ import { DEFAULT_EXPLAIN_PROMPT } from "@/lib/types";
 import { getSetting } from "@/lib/db";
 import { getRequestContext } from "@cloudflare/next-on-pages";
 
+const SourceSchema = z.object({
+  uri: z.string(),
+  title: z.string(),
+});
+
 const AiResponseSchema = z.object({
   explanation: z.string(),
   answers: z.array(z.string()),
   reasoning: z.string(),
+  sources: z.array(SourceSchema).optional(),
 });
+
+const ALLOWED_DOMAINS = [
+  "trailhead.salesforce.com",
+  "developer.salesforce.com",
+  "www.salesforce.com",
+  "help.salesforce.com",
+];
 
 export type AiExplainResponse = z.infer<typeof AiResponseSchema>;
 
@@ -35,16 +48,18 @@ export async function POST(req: NextRequest) {
   const explanationLine = body.explanation ? `Current explanation on record: ${body.explanation}` : "";
 
   const template = body.userPrompt || DEFAULT_EXPLAIN_PROMPT;
+  const domainHint = `\n\nWhen searching the web, prioritize official Salesforce documentation from: trailhead.salesforce.com, developer.salesforce.com, help.salesforce.com, www.salesforce.com.`;
   const prompt = template
     .replace("{question}", body.question)
     .replace("{choices}", choicesText)
     .replace("{answers}", body.answers.join(", "))
-    .replace("{explanation}", explanationLine);
+    .replace("{explanation}", explanationLine) + domainHint;
 
   const ai = new GoogleGenAI({ apiKey });
   const model = (await getSetting("gemini_model")) ?? "gemini-2.5-flash";
 
   let raw: string;
+  let sources: { uri: string; title: string }[] = [];
   try {
     const response = await ai.models.generateContent({
       model,
@@ -54,6 +69,18 @@ export async function POST(req: NextRequest) {
       },
     });
     raw = response.text ?? "";
+
+    // Extract grounding sources, filtered to allowed Salesforce domains
+    const chunks = response.candidates?.[0]?.groundingMetadata?.groundingChunks ?? [];
+    sources = chunks
+      .filter((c) => {
+        if (!c.web?.uri) return false;
+        try {
+          const host = new URL(c.web.uri).hostname;
+          return ALLOWED_DOMAINS.includes(host);
+        } catch { return false; }
+      })
+      .map((c) => ({ uri: c.web!.uri!, title: c.web!.title ?? c.web!.uri! }));
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ error: `Gemini API error: ${msg}` }, { status: 502 });
@@ -80,5 +107,5 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  return NextResponse.json(result.data);
+  return NextResponse.json({ ...result.data, sources: sources.length > 0 ? sources : undefined });
 }

--- a/components/AiExplainPopup.tsx
+++ b/components/AiExplainPopup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2, Sparkles, X, CheckCheck } from "lucide-react";
+import { Loader2, Sparkles, X, CheckCheck, ExternalLink } from "lucide-react";
 import type { AiExplainResponse } from "@/app/api/ai/explain/route";
 import { useSettings } from "@/lib/settings-context";
 
@@ -83,6 +83,29 @@ export default function AiExplainPopup({ loading, result, error, adopting, onAdo
                 {result.reasoning}
               </p>
             </div>
+
+            {/* Sources */}
+            {result.sources && result.sources.length > 0 && (
+              <div>
+                <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">
+                  Sources
+                </p>
+                <div className="flex flex-col gap-1">
+                  {result.sources.map((s) => (
+                    <a
+                      key={s.uri}
+                      href={s.uri}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-xs text-violet-500 hover:text-violet-700 hover:underline"
+                    >
+                      <ExternalLink size={10} className="shrink-0" />
+                      <span className="truncate">{s.title}</span>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add domain hint to prompt to prioritize Salesforce docs (trailhead, developer, help, www)
- Extract `groundingMetadata.groundingChunks` from Gemini API response
- Filter chunks to allowed Salesforce domains and expose as `sources` field
- Display clickable source links in AiExplainPopup with ExternalLink icon

## Test plan
- [ ] Trigger AI Explain on a question — sources section appears at bottom of popup
- [ ] Sources link to trailhead.salesforce.com, developer.salesforce.com, etc.
- [ ] No sources section shown if none returned from Salesforce domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)