### PR TITLE
feat: restrict access to @salesforce.com domain via middleware

### DIFF
--- a/app/unauthorized/page.tsx
+++ b/app/unauthorized/page.tsx
@@ -1,0 +1,21 @@
+import { ShieldX } from "lucide-react";
+import { getUserEmail } from "@/lib/user";
+
+export const runtime = "edge";
+
+export default async function UnauthorizedPage() {
+  const email = await getUserEmail();
+  return (
+    <div className="min-h-screen bg-[#f8f9fb] flex flex-col items-center justify-center p-8">
+      <div className="bg-white rounded-2xl border border-gray-200 p-10 max-w-sm w-full text-center space-y-4">
+        <ShieldX size={32} className="mx-auto text-red-400" strokeWidth={1.5} />
+        <h1 className="text-base font-semibold text-gray-900">Access Restricted</h1>
+        <p className="text-sm text-gray-500">
+          This app is available to{" "}
+          <span className="font-medium text-gray-700">@salesforce.com</span> accounts only.
+        </p>
+        <p className="text-xs text-gray-400 font-mono">{email}</p>
+      </div>
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,11 @@
+// Domain restriction for access control.
+// To allow additional domains, add them to ALLOWED_DOMAINS.
+// To disable domain restriction entirely, set ALLOWED_DOMAINS to null.
+const ALLOWED_DOMAINS: string[] | null = ["salesforce.com"];
+// const ALLOWED_DOMAINS: string[] | null = null; // unrestricted mode
+
+export function isEmailAllowed(email: string | null): boolean {
+  if (email === null) return true; // local dev: CF header absent
+  if (ALLOWED_DOMAINS === null) return true; // unrestricted mode
+  return ALLOWED_DOMAINS.some((d) => email.endsWith(`@${d}`));
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isEmailAllowed } from "@/lib/auth";
+
+export function middleware(request: NextRequest) {
+  // Avoid redirect loop on the unauthorized page itself
+  if (request.nextUrl.pathname.startsWith("/unauthorized")) {
+    return NextResponse.next();
+  }
+
+  const email = request.headers.get("Cf-Access-Authenticated-User-Email");
+  if (!isEmailAllowed(email)) {
+    return NextResponse.redirect(new URL("/unauthorized", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    // Match all paths except Next.js internals and static assets
+    "/((?!_next/static|_next/image|favicon.ico).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- `lib/auth.ts` を新規作成。`ALLOWED_DOMAINS` 定数でドメイン制限を管理（`null` にすれば制限解除）
- `middleware.ts` を新規作成。`Cf-Access-Authenticated-User-Email` ヘッダーを読み、`@salesforce.com` 以外は `/unauthorized` にリダイレクト
- `app/unauthorized/page.tsx` を新規作成。ブロックされたユーザーにメールアドレス付きで理由を表示

## Notes
- OTP は Cloudflare Access 側で処理済みのため、アプリ側の追加実装なし
- ローカル開発（CF ヘッダーなし = `null`）は自動バイパス
- 将来的に制限を緩和する場合は `ALLOWED_DOMAINS` に追加するか `null` に変更するだけ

## Test plan
- [ ] `npm run dev` でローカル起動 → 通常通りアクセス可（ヘッダーなしバイパス）
- [ ] 本番環境で `@salesforce.com` アカウント → 通過
- [ ] 本番環境で他ドメインアカウント → `/unauthorized` にリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)