### PR TITLE
fix: prevent page scroll and fix squished choices on long questions

### DIFF
--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -441,7 +441,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const q = filteredQuestions[currentIndex];
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-[#f8f9fb]">
+    <div className="h-[100dvh] flex flex-col overflow-hidden bg-[#f8f9fb]">
       {/* ── Header ── */}
       <header className="shrink-0 flex items-center justify-between px-4 sm:px-6 h-12 border-b border-gray-200 bg-white">
         <div className="flex items-center gap-3 sm:gap-4 min-w-0">
@@ -537,7 +537,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
                               Edit
                             </button>
                           </div>
-                          <div className="bg-gray-50 rounded-xl px-5 py-4 lg:px-6 lg:py-5 mb-4">
+                          <div className="bg-gray-50 rounded-xl px-5 py-4 lg:px-6 lg:py-5 mb-4 max-h-[40vh] overflow-y-auto">
                             <div
                               className="text-gray-900 text-sm lg:text-base leading-relaxed font-medium whitespace-pre-wrap [&_img]:max-w-full [&_img]:rounded-lg [&_img]:mt-2"
                               dangerouslySetInnerHTML={{ __html: q.question }}

--- a/components/QuizQuestion.tsx
+++ b/components/QuizQuestion.tsx
@@ -40,8 +40,8 @@ export default function QuizQuestion({
         )}
       </div>
 
-      {/* Question text */}
-      <div className="bg-gray-50 rounded-xl px-5 py-4 lg:px-6 lg:py-5 mb-4 shrink-0">
+      {/* Question text — capped height, scrollable if very long */}
+      <div className="bg-gray-50 rounded-xl px-5 py-4 lg:px-6 lg:py-5 mb-4 shrink-0 max-h-[40vh] overflow-y-auto">
         <div
           className="text-gray-900 text-sm lg:text-base leading-relaxed font-medium whitespace-pre-wrap [&_img]:max-w-full [&_img]:rounded-lg [&_img]:mt-2"
           dangerouslySetInnerHTML={{ __html: question.question }}
@@ -49,7 +49,7 @@ export default function QuizQuestion({
       </div>
 
       {/* Choices — scrollable if many */}
-      <div className="space-y-2 overflow-y-auto flex-1 pr-1">
+      <div className="space-y-2 overflow-y-auto flex-1 min-h-0 pr-1">
         {question.choices.map((choice, i) => {
           const isSelected = selected.has(choice.label);
           const isAnswer = question.answers.includes(choice.label);


### PR DESCRIPTION
## Summary
- `h-[100dvh]` instead of `h-screen` — accounts for mobile browser address bar so the page never scrolls
- Question text capped at `max-h-[40vh] overflow-y-auto` — long questions scroll within their own box instead of consuming all vertical space
- `min-h-0` added to choices container — enables proper flexbox overflow so choices scroll independently
- Same question text cap applied in review mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)