### PR TITLE
feat: add OTP/password login with first-time email verification

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRequestContext } from "@cloudflare/next-on-pages";
+import { deleteAuthSession } from "@/lib/auth";
+import type { D1Database } from "@/lib/db";
+
+export const runtime = "edge";
+
+function getDB(): D1Database | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (getRequestContext() as any).env.DB as D1Database ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get("__session")?.value;
+
+  if (token) {
+    const db = getDB();
+    if (db) {
+      await deleteAuthSession(db, token);
+    }
+  }
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.delete("__session");
+  return res;
+}

--- a/app/api/auth/otp/send/route.ts
+++ b/app/api/auth/otp/send/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRequestContext } from "@cloudflare/next-on-pages";
+import { isEmailAllowed, getOrCreateUser, createOtp, validateAuthSession } from "@/lib/auth";
+import type { D1Database } from "@/lib/db";
+
+export const runtime = "edge";
+
+function getDB(): D1Database | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (getRequestContext() as any).env.DB as D1Database ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function sendOtpEmail(
+  to: string,
+  code: string,
+  resendApiKey: string
+): Promise<void> {
+  const from = process.env.EMAIL_FROM ?? "onboarding@resend.dev";
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: [to],
+      subject: "Your sign-in code",
+      text: `Your sign-in code is: ${code}\n\nThis code expires in 10 minutes. Do not share it with anyone.`,
+    }),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json() as { email?: string; purpose?: string };
+  const purpose = (body.purpose === "verify" ? "verify" : "login") as "login" | "verify";
+
+  let email: string;
+
+  if (purpose === "verify") {
+    // For verification, email comes from the current session
+    const db = getDB();
+    if (!db) return NextResponse.json({ error: "DB not available" }, { status: 500 });
+    const token = req.cookies.get("__session")?.value;
+    if (!token) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    const session = await validateAuthSession(db, token);
+    if (!session) return NextResponse.json({ error: "Invalid session" }, { status: 401 });
+    email = session.userEmail;
+  } else {
+    // For login, email comes from the request body
+    email = (body.email ?? "").trim().toLowerCase();
+    if (!email) return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    if (!isEmailAllowed(email)) {
+      return NextResponse.json({ error: "Access restricted to @salesforce.com accounts" }, { status: 403 });
+    }
+  }
+
+  const db = getDB();
+  if (!db) {
+    // Local dev: skip email, just log the code
+    return NextResponse.json({ ok: true, dev: true });
+  }
+
+  await getOrCreateUser(db, email);
+
+  const result = await createOtp(db, email, purpose);
+  if ("rateLimited" in result) {
+    return NextResponse.json({ error: "Too many requests. Try again later." }, { status: 429 });
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (resendApiKey) {
+    try {
+      await sendOtpEmail(email, result.code, resendApiKey);
+    } catch {
+      return NextResponse.json({ error: "Failed to send email" }, { status: 500 });
+    }
+  } else {
+    // Dev: RESEND_API_KEY not set — log code to console
+    console.info(`[DEV] OTP for ${email} (${purpose}): ${result.code}`);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/auth/otp/verify/route.ts
+++ b/app/api/auth/otp/verify/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRequestContext } from "@cloudflare/next-on-pages";
+import {
+  isEmailAllowed,
+  getOrCreateUser,
+  verifyOtp,
+  createAuthSession,
+  setUserVerified,
+  validateAuthSession,
+} from "@/lib/auth";
+import type { D1Database } from "@/lib/db";
+
+export const runtime = "edge";
+
+function getDB(): D1Database | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (getRequestContext() as any).env.DB as D1Database ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+export async function POST(req: NextRequest) {
+  const body = await req.json() as { email?: string; code?: string; purpose?: string };
+  const purpose = (body.purpose === "verify" ? "verify" : "login") as "login" | "verify";
+  const code = (body.code ?? "").trim();
+
+  if (!code || !/^\d{6}$/.test(code)) {
+    return NextResponse.json({ error: "Invalid code format" }, { status: 400 });
+  }
+
+  const db = getDB();
+  if (!db) {
+    return NextResponse.json({ error: "DB not available" }, { status: 500 });
+  }
+
+  let email: string;
+
+  if (purpose === "verify") {
+    // Email comes from the current session
+    const token = req.cookies.get("__session")?.value;
+    if (!token) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    const session = await validateAuthSession(db, token);
+    if (!session) return NextResponse.json({ error: "Invalid session" }, { status: 401 });
+    email = session.userEmail;
+
+    const valid = await verifyOtp(db, email, code, "verify");
+    if (!valid) {
+      return NextResponse.json({ error: "Invalid or expired code" }, { status: 401 });
+    }
+
+    await setUserVerified(db, email);
+    return NextResponse.json({ ok: true });
+  } else {
+    // Login OTP
+    email = (body.email ?? "").trim().toLowerCase();
+    if (!email) return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    if (!isEmailAllowed(email)) {
+      return NextResponse.json({ error: "Access restricted to @salesforce.com accounts" }, { status: 403 });
+    }
+
+    const valid = await verifyOtp(db, email, code, "login");
+    if (!valid) {
+      return NextResponse.json({ error: "Invalid or expired code" }, { status: 401 });
+    }
+
+    const { emailVerified } = await getOrCreateUser(db, email);
+
+    const ua = req.headers.get("user-agent") ?? undefined;
+    const ip = req.headers.get("cf-connecting-ip") ?? undefined;
+    const token = await createAuthSession(db, email, ua, ip);
+
+    const res = NextResponse.json({
+      ok: true,
+      redirect: emailVerified ? "/" : "/verify",
+    });
+
+    res.cookies.set("__session", token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: COOKIE_MAX_AGE,
+    });
+
+    return res;
+  }
+}

--- a/app/api/auth/password/route.ts
+++ b/app/api/auth/password/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRequestContext } from "@cloudflare/next-on-pages";
+import { isEmailAllowed, getOrCreateUser, checkUserPassword, createAuthSession } from "@/lib/auth";
+import type { D1Database } from "@/lib/db";
+
+export const runtime = "edge";
+
+function getDB(): D1Database | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (getRequestContext() as any).env.DB as D1Database ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+export async function POST(req: NextRequest) {
+  const body = await req.json() as { email?: string; password?: string };
+  const email = (body.email ?? "").trim().toLowerCase();
+  const password = body.password ?? "";
+
+  if (!email || !password) {
+    return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
+  }
+
+  if (!isEmailAllowed(email)) {
+    return NextResponse.json({ error: "Access restricted to @salesforce.com accounts" }, { status: 403 });
+  }
+
+  const db = getDB();
+  if (!db) {
+    return NextResponse.json({ error: "DB not available" }, { status: 500 });
+  }
+
+  // Ensure user row exists
+  await getOrCreateUser(db, email);
+
+  const { ok, emailVerified } = await checkUserPassword(db, email, password);
+  if (!ok) {
+    // Use a generic error to avoid user enumeration
+    return NextResponse.json({ error: "Invalid email or password" }, { status: 401 });
+  }
+
+  const ua = req.headers.get("user-agent") ?? undefined;
+  const ip = req.headers.get("cf-connecting-ip") ?? undefined;
+  const token = await createAuthSession(db, email, ua, ip);
+
+  const res = NextResponse.json({
+    ok: true,
+    redirect: emailVerified ? "/" : "/verify",
+  });
+
+  res.cookies.set("__session", token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: COOKIE_MAX_AGE,
+  });
+
+  return res;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Mail, Lock, ArrowRight, Loader2 } from "lucide-react";
+
+type Mode = "otp" | "password";
+type OtpStep = "email" | "code";
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next") ?? "/";
+
+  const [mode, setMode] = useState<Mode>("otp");
+  const [otpStep, setOtpStep] = useState<OtpStep>("email");
+
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSendOtp(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/otp/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, purpose: "login" }),
+      });
+      const data = await res.json() as { error?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Failed to send code");
+        return;
+      }
+      setOtpStep("code");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleVerifyOtp(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/otp/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code, purpose: "login" }),
+      });
+      const data = await res.json() as { error?: string; redirect?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Invalid or expired code");
+        return;
+      }
+      router.push(data.redirect ?? next);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handlePasswordLogin(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json() as { error?: string; redirect?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Invalid credentials");
+        return;
+      }
+      router.push(data.redirect ?? next);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f8f9fb] flex flex-col items-center justify-center p-8">
+      <div className="bg-white rounded-2xl border border-gray-200 p-8 max-w-sm w-full space-y-6">
+        {/* Header */}
+        <div className="text-center space-y-1">
+          <h1 className="text-base font-semibold text-gray-900">Sign in</h1>
+          <p className="text-xs text-gray-400">@salesforce.com accounts only</p>
+        </div>
+
+        {/* Mode toggle */}
+        <div className="flex rounded-lg border border-gray-200 overflow-hidden text-sm">
+          <button
+            type="button"
+            onClick={() => { setMode("otp"); setOtpStep("email"); setError(""); }}
+            className={`flex-1 py-2 font-medium transition-colors ${
+              mode === "otp"
+                ? "bg-gray-900 text-white"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            Email code
+          </button>
+          <button
+            type="button"
+            onClick={() => { setMode("password"); setError(""); }}
+            className={`flex-1 py-2 font-medium transition-colors ${
+              mode === "password"
+                ? "bg-gray-900 text-white"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            Password
+          </button>
+        </div>
+
+        {/* OTP mode */}
+        {mode === "otp" && otpStep === "email" && (
+          <form onSubmit={handleSendOtp} className="space-y-4">
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">Email</label>
+              <div className="relative">
+                <Mail size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@salesforce.com"
+                  required
+                  className="w-full pl-9 pr-3 py-2.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:border-gray-400 bg-white"
+                />
+              </div>
+            </div>
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full flex items-center justify-center gap-2 py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 disabled:opacity-50 transition-colors"
+            >
+              {loading ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <>Send code <ArrowRight size={14} /></>
+              )}
+            </button>
+          </form>
+        )}
+
+        {mode === "otp" && otpStep === "code" && (
+          <form onSubmit={handleVerifyOtp} className="space-y-4">
+            <div className="text-xs text-gray-500 bg-gray-50 rounded-lg px-3 py-2">
+              Code sent to <span className="font-medium text-gray-700">{email}</span>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">6-digit code</label>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]{6}"
+                maxLength={6}
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                placeholder="000000"
+                required
+                autoFocus
+                className="w-full px-3 py-2.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:border-gray-400 bg-white tracking-widest text-center font-mono"
+              />
+            </div>
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading || code.length !== 6}
+              className="w-full flex items-center justify-center gap-2 py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 disabled:opacity-50 transition-colors"
+            >
+              {loading ? <Loader2 size={14} className="animate-spin" /> : "Verify"}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setOtpStep("email"); setCode(""); setError(""); }}
+              className="w-full text-xs text-gray-400 hover:text-gray-600"
+            >
+              Use a different email
+            </button>
+          </form>
+        )}
+
+        {/* Password mode */}
+        {mode === "password" && (
+          <form onSubmit={handlePasswordLogin} className="space-y-4">
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">Email</label>
+              <div className="relative">
+                <Mail size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@salesforce.com"
+                  required
+                  className="w-full pl-9 pr-3 py-2.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:border-gray-400 bg-white"
+                />
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">Password</label>
+              <div className="relative">
+                <Lock size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  required
+                  className="w-full pl-9 pr-3 py-2.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:border-gray-400 bg-white"
+                />
+              </div>
+            </div>
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full flex items-center justify-center gap-2 py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 disabled:opacity-50 transition-colors"
+            >
+              {loading ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <>Sign in <ArrowRight size={14} /></>
+              )}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { MailCheck, Loader2 } from "lucide-react";
+
+export default function VerifyPage() {
+  const router = useRouter();
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [error, setError] = useState("");
+  const [resendMsg, setResendMsg] = useState("");
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/otp/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code, purpose: "verify" }),
+      });
+      const data = await res.json() as { error?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Invalid or expired code");
+        return;
+      }
+      router.push("/");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleResend() {
+    setResendMsg("");
+    setError("");
+    setResending(true);
+    try {
+      const res = await fetch("/api/auth/otp/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ purpose: "verify" }),
+      });
+      const data = await res.json() as { error?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Failed to resend code");
+        return;
+      }
+      setResendMsg("Code resent");
+    } finally {
+      setResending(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f8f9fb] flex flex-col items-center justify-center p-8">
+      <div className="bg-white rounded-2xl border border-gray-200 p-8 max-w-sm w-full space-y-6 text-center">
+        <MailCheck size={32} className="mx-auto text-gray-400" strokeWidth={1.5} />
+
+        <div className="space-y-1">
+          <h1 className="text-base font-semibold text-gray-900">Verify your email</h1>
+          <p className="text-xs text-gray-500">
+            We sent a 6-digit code to your email address. Enter it below to confirm your account.
+          </p>
+        </div>
+
+        <form onSubmit={handleVerify} className="space-y-4 text-left">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-gray-600">Verification code</label>
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]{6}"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              placeholder="000000"
+              required
+              autoFocus
+              className="w-full px-3 py-2.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:border-gray-400 bg-white tracking-widest text-center font-mono"
+            />
+          </div>
+
+          {error && <p className="text-xs text-red-500">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={loading || code.length !== 6}
+            className="w-full flex items-center justify-center gap-2 py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 disabled:opacity-50 transition-colors"
+          >
+            {loading ? <Loader2 size={14} className="animate-spin" /> : "Verify email"}
+          </button>
+        </form>
+
+        <div className="space-y-1">
+          <button
+            type="button"
+            onClick={handleResend}
+            disabled={resending}
+            className="text-xs text-gray-400 hover:text-gray-600 disabled:opacity-50"
+          >
+            {resending ? "Sending..." : "Resend code"}
+          </button>
+          {resendMsg && <p className="text-xs text-green-600">{resendMsg}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,7 @@
-// Domain restriction for access control.
+import type { D1Database } from "./db";
+import { generateOtp, generateSessionToken, hashPassword, verifyPassword } from "./crypto";
+
+// ── Domain restriction ──────────────────────────────────────────────────────
 // To allow additional domains, add them to ALLOWED_DOMAINS.
 // To disable domain restriction entirely, set ALLOWED_DOMAINS to null.
 const ALLOWED_DOMAINS: string[] | null = ["salesforce.com"];
@@ -8,4 +11,220 @@ export function isEmailAllowed(email: string | null): boolean {
   if (email === null) return true; // local dev: CF header absent
   if (ALLOWED_DOMAINS === null) return true; // unrestricted mode
   return ALLOWED_DOMAINS.some((d) => email.endsWith(`@${d}`));
+}
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface SessionInfo {
+  userEmail: string;
+  emailVerified: boolean;
+}
+
+// ── User ────────────────────────────────────────────────────────────────────
+
+/** Upsert a users row. Returns the row's email_verified state. */
+export async function getOrCreateUser(
+  db: D1Database,
+  email: string
+): Promise<{ emailVerified: boolean }> {
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO users (email, email_verified, created_at)
+       VALUES (?, 0, datetime('now'))`
+    )
+    .bind(email)
+    .run();
+
+  const row = await db
+    .prepare("SELECT email_verified FROM users WHERE email = ?")
+    .bind(email)
+    .first<{ email_verified: number }>();
+
+  return { emailVerified: (row?.email_verified ?? 0) === 1 };
+}
+
+export async function setUserVerified(
+  db: D1Database,
+  email: string
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE users SET email_verified = 1, last_login_at = datetime('now') WHERE email = ?`
+    )
+    .bind(email)
+    .run();
+}
+
+export async function setUserPassword(
+  db: D1Database,
+  email: string,
+  password: string
+): Promise<void> {
+  const { hash, salt } = await hashPassword(password);
+  await db
+    .prepare(
+      `UPDATE users SET password_hash = ?, password_salt = ? WHERE email = ?`
+    )
+    .bind(hash, salt, email)
+    .run();
+}
+
+export async function checkUserPassword(
+  db: D1Database,
+  email: string,
+  password: string
+): Promise<{ ok: boolean; emailVerified: boolean }> {
+  const row = await db
+    .prepare(
+      "SELECT password_hash, password_salt, email_verified FROM users WHERE email = ?"
+    )
+    .bind(email)
+    .first<{
+      password_hash: string | null;
+      password_salt: string | null;
+      email_verified: number;
+    }>();
+
+  if (!row || !row.password_hash || !row.password_salt) {
+    return { ok: false, emailVerified: false };
+  }
+
+  const ok = await verifyPassword(password, row.password_hash, row.password_salt);
+  return { ok, emailVerified: (row.email_verified ?? 0) === 1 };
+}
+
+// ── OTP ─────────────────────────────────────────────────────────────────────
+
+const OTP_TTL_MINUTES = 10;
+const OTP_RATE_LIMIT_PER_HOUR = 5;
+
+export async function createOtp(
+  db: D1Database,
+  email: string,
+  purpose: "login" | "verify"
+): Promise<{ code: string } | { rateLimited: true }> {
+  // Rate limiting: max OTP_RATE_LIMIT_PER_HOUR sends per hour
+  const recent = await db
+    .prepare(
+      `SELECT COUNT(*) AS cnt FROM otp_codes
+       WHERE user_email = ? AND created_at > datetime('now', '-1 hour')`
+    )
+    .bind(email)
+    .first<{ cnt: number }>();
+
+  if ((recent?.cnt ?? 0) >= OTP_RATE_LIMIT_PER_HOUR) {
+    return { rateLimited: true };
+  }
+
+  // Invalidate old unused codes for same email+purpose
+  await db
+    .prepare(
+      `UPDATE otp_codes SET used = 1
+       WHERE user_email = ? AND purpose = ? AND used = 0`
+    )
+    .bind(email, purpose)
+    .run();
+
+  const code = generateOtp();
+  await db
+    .prepare(
+      `INSERT INTO otp_codes (user_email, code, purpose, created_at, expires_at)
+       VALUES (?, ?, ?, datetime('now'), datetime('now', '+${OTP_TTL_MINUTES} minutes'))`
+    )
+    .bind(email, code, purpose)
+    .run();
+
+  return { code };
+}
+
+export async function verifyOtp(
+  db: D1Database,
+  email: string,
+  code: string,
+  purpose: "login" | "verify"
+): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT id FROM otp_codes
+       WHERE user_email = ? AND code = ? AND purpose = ?
+         AND used = 0 AND expires_at > datetime('now')
+       ORDER BY created_at DESC LIMIT 1`
+    )
+    .bind(email, code, purpose)
+    .first<{ id: number }>();
+
+  if (!row) return false;
+
+  await db
+    .prepare("UPDATE otp_codes SET used = 1 WHERE id = ?")
+    .bind(row.id)
+    .run();
+
+  return true;
+}
+
+// ── Auth sessions ───────────────────────────────────────────────────────────
+
+const SESSION_TTL_DAYS = 30;
+
+export async function createAuthSession(
+  db: D1Database,
+  userEmail: string,
+  userAgent?: string,
+  ip?: string
+): Promise<string> {
+  const token = generateSessionToken();
+  await db
+    .prepare(
+      `INSERT INTO auth_sessions (id, user_email, created_at, expires_at, user_agent, ip)
+       VALUES (?, ?, datetime('now'), datetime('now', '+${SESSION_TTL_DAYS} days'), ?, ?)`
+    )
+    .bind(token, userEmail, userAgent ?? null, ip ?? null)
+    .run();
+  return token;
+}
+
+export async function validateAuthSession(
+  db: D1Database,
+  token: string
+): Promise<SessionInfo | null> {
+  const row = await db
+    .prepare(
+      `SELECT s.user_email, u.email_verified
+       FROM auth_sessions s
+       JOIN users u ON u.email = s.user_email
+       WHERE s.id = ? AND s.expires_at > datetime('now')`
+    )
+    .bind(token)
+    .first<{ user_email: string; email_verified: number }>();
+
+  if (!row) return null;
+  return {
+    userEmail: row.user_email,
+    emailVerified: row.email_verified === 1,
+  };
+}
+
+export async function deleteAuthSession(
+  db: D1Database,
+  token: string
+): Promise<void> {
+  await db
+    .prepare("DELETE FROM auth_sessions WHERE id = ?")
+    .bind(token)
+    .run();
+}
+
+export async function touchSession(
+  db: D1Database,
+  token: string
+): Promise<void> {
+  // Extend session expiry on activity
+  await db
+    .prepare(
+      `UPDATE auth_sessions SET expires_at = datetime('now', '+${SESSION_TTL_DAYS} days')
+       WHERE id = ?`
+    )
+    .bind(token)
+    .run();
 }

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,0 +1,93 @@
+// Edge-compatible cryptographic utilities (Web Crypto API only — no Node.js)
+
+/** Generate a cryptographically secure random hex string of given byte length */
+export function randomHex(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return Array.from(buf)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Generate a 6-digit OTP code */
+export function generateOtp(): string {
+  const arr = new Uint32Array(1);
+  crypto.getRandomValues(arr);
+  return String(arr[0] % 1_000_000).padStart(6, "0");
+}
+
+/** Generate a 64-char hex session token (32 random bytes) */
+export function generateSessionToken(): string {
+  return randomHex(32);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const buf = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    buf[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return buf;
+}
+
+/** Hash a password using PBKDF2-SHA256. Returns { hash, salt } as hex strings. */
+export async function hashPassword(
+  password: string
+): Promise<{ hash: string; salt: string }> {
+  const salt = randomHex(16); // 16 random bytes
+  const saltBytes = hexToBytes(salt);
+
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
+
+  const derived = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", hash: "SHA-256", salt: saltBytes.buffer as ArrayBuffer, iterations: 100_000 },
+    keyMaterial,
+    256
+  );
+
+  const hash = Array.from(new Uint8Array(derived))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return { hash, salt };
+}
+
+/** Constant-time byte comparison to prevent timing attacks */
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+/** Verify a password against stored hash + salt (both hex strings) */
+export async function verifyPassword(
+  password: string,
+  storedHash: string,
+  storedSalt: string
+): Promise<boolean> {
+  const saltBytes = hexToBytes(storedSalt);
+
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
+
+  const derived = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", hash: "SHA-256", salt: saltBytes.buffer as ArrayBuffer, iterations: 100_000 },
+    keyMaterial,
+    256
+  );
+
+  return constantTimeEqual(new Uint8Array(derived), hexToBytes(storedHash));
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,19 +2,19 @@ import type { CategoryStat, Choice, ExamMeta, Question, QuestionHistoryEntry, Qu
 import { getRequestContext } from "@cloudflare/next-on-pages";
 
 // Minimal D1 type stub – replaced by @cloudflare/workers-types after npm install
-interface D1PreparedStatement {
+export interface D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
   all<T = unknown>(): Promise<{ results: T[] }>;
   first<T = unknown>(): Promise<T | null>;
   run(): Promise<void>;
 }
-interface D1Database {
+export interface D1Database {
   prepare(query: string): D1PreparedStatement;
 }
 
 // ── Runtime detection ─────────────────────────────────────────────────────
 
-function getDB(): D1Database | null {
+export function getDB(): D1Database | null {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (getRequestContext() as any).env.DB as D1Database ?? null;

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,10 +1,17 @@
 import { headers } from "next/headers";
 
 /**
- * Returns the authenticated user's email from Cloudflare Access headers.
- * Falls back to "local@dev" in local development.
+ * Returns the authenticated user's email.
+ * Priority:
+ *   1. x-user-email  — injected by middleware after session validation
+ *   2. Cf-Access-Authenticated-User-Email — Cloudflare Access (legacy / local CF tunnel)
+ *   3. "local@dev"   — local development fallback
  */
 export async function getUserEmail(): Promise<string> {
   const h = await headers();
-  return h.get("Cf-Access-Authenticated-User-Email") ?? "local@dev";
+  return (
+    h.get("x-user-email") ??
+    h.get("Cf-Access-Authenticated-User-Email") ??
+    "local@dev"
+  );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,23 +1,82 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isEmailAllowed } from "@/lib/auth";
+import { getRequestContext } from "@cloudflare/next-on-pages";
+import { isEmailAllowed, validateAuthSession } from "@/lib/auth";
+import type { D1Database } from "@/lib/db";
 
-export function middleware(request: NextRequest) {
-  // Avoid redirect loop on the unauthorized page itself
-  if (request.nextUrl.pathname.startsWith("/unauthorized")) {
+// Paths that are always public (no auth required)
+const PUBLIC_PREFIXES = [
+  "/login",
+  "/verify",
+  "/unauthorized",
+  "/api/auth/",
+  "/_next/",
+  "/favicon.ico",
+];
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+function getDB(): D1Database | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (getRequestContext() as any).env.DB as D1Database ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (isPublicPath(pathname)) {
     return NextResponse.next();
   }
 
-  const email = request.headers.get("Cf-Access-Authenticated-User-Email");
-  if (!isEmailAllowed(email)) {
-    return NextResponse.redirect(new URL("/unauthorized", request.url));
+  // ── Local dev: no D1 available, skip auth ─────────────────────────────
+  const db = getDB();
+  if (!db) {
+    // Still check CF Access header for domain restriction when present
+    const cfEmail = request.headers.get("Cf-Access-Authenticated-User-Email");
+    if (cfEmail !== null && !isEmailAllowed(cfEmail)) {
+      return NextResponse.redirect(new URL("/unauthorized", request.url));
+    }
+    return NextResponse.next();
   }
 
-  return NextResponse.next();
+  // ── Session cookie auth ───────────────────────────────────────────────
+  const token = request.cookies.get("__session")?.value;
+  if (!token) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("next", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const session = await validateAuthSession(db, token);
+  if (!session) {
+    // Stale/expired token — clear cookie and redirect to login
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("next", pathname);
+    const res = NextResponse.redirect(loginUrl);
+    res.cookies.delete("__session");
+    return res;
+  }
+
+  // ── First-time email verification gate ───────────────────────────────
+  if (!session.emailVerified && pathname !== "/verify") {
+    return NextResponse.redirect(new URL("/verify", request.url));
+  }
+
+  // ── Inject user email for downstream Server Components / API routes ──
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-user-email", session.userEmail);
+
+  return NextResponse.next({ request: { headers: requestHeaders } });
 }
 
 export const config = {
   matcher: [
-    // Match all paths except Next.js internals and static assets
+    // Match all paths except Next.js static files
     "/((?!_next/static|_next/image|favicon.ico).*)",
   ],
 };

--- a/migrations/0008_auth.sql
+++ b/migrations/0008_auth.sql
@@ -1,0 +1,34 @@
+-- Auth tables: users, auth_sessions, otp_codes
+
+CREATE TABLE IF NOT EXISTS users (
+  email           TEXT PRIMARY KEY,
+  password_hash   TEXT,            -- NULL = OTP-only user (PBKDF2 hex)
+  password_salt   TEXT,
+  email_verified  INTEGER NOT NULL DEFAULT 0,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  last_login_at   TEXT
+);
+
+CREATE TABLE IF NOT EXISTS auth_sessions (
+  id          TEXT PRIMARY KEY,        -- 64-char hex (32 random bytes)
+  user_email  TEXT NOT NULL REFERENCES users(email),
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at  TEXT NOT NULL,
+  user_agent  TEXT,
+  ip          TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_email ON auth_sessions(user_email);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires ON auth_sessions(expires_at);
+
+CREATE TABLE IF NOT EXISTS otp_codes (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_email  TEXT NOT NULL,
+  code        TEXT NOT NULL,           -- 6-digit plain text (ephemeral)
+  purpose     TEXT NOT NULL CHECK (purpose IN ('login', 'verify')),
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at  TEXT NOT NULL,
+  used        INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_otp_email ON otp_codes(user_email, purpose);


### PR DESCRIPTION
## Summary

- Add `/login` page with OTP (email code) / password mode toggle
- Add `/verify` page for first-time email verification gate
- Session cookie auth (`__session`, httpOnly, 30-day TTL) backed by D1 `auth_sessions` table
- Domain restriction (`@salesforce.com`) enforced at API layer via `isEmailAllowed()`
- OTP: 6-digit code sent via Resend (`onboarding@resend.dev`), 10-min TTL, rate-limited to 5/hour per email
- Password: PBKDF2-SHA256 (100k iterations) via Web Crypto API (edge-compatible, no bcrypt)
- First-time users: redirected to `/verify` after login until `email_verified = 1`
- Local dev: auth skipped when D1 is unavailable, `local@dev` fallback preserved

## New files

| File | Purpose |
|---|---|
| `migrations/0008_auth.sql` | `users`, `auth_sessions`, `otp_codes` tables |
| `lib/crypto.ts` | PBKDF2, OTP gen, session token gen |
| `app/login/page.tsx` | Login UI |
| `app/verify/page.tsx` | Email verification UI |
| `app/api/auth/otp/send/route.ts` | Send OTP via Resend |
| `app/api/auth/otp/verify/route.ts` | Verify OTP, issue session |
| `app/api/auth/password/route.ts` | Password login, issue session |
| `app/api/auth/logout/route.ts` | Delete session + clear cookie |

## Post-merge steps

1. Set `RESEND_API_KEY` as Cloudflare Pages secret: `wrangler secret put RESEND_API_KEY`
2. Apply migration to production D1: `scripts/migrate-d1.sh 0008_auth.sql`

## Test plan

- [ ] OTP flow: enter @salesforce.com email → receive code → enter → session issued → redirect to `/`
- [ ] Non-salesforce.com email → 403 error shown in UI
- [ ] First-time user: login → redirect to `/verify` → enter code → `email_verified=1` → `/`
- [ ] Password flow: email + correct password → session → redirect
- [ ] Wrong password → "Invalid email or password" error
- [ ] Logout: session deleted, cookie cleared, redirect to `/login`
- [ ] Expired/tampered session cookie → redirect to `/login`
- [ ] Local dev (`npm run dev`): auth skipped, app works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)