### PR TITLE
feat: add daily streak and goal tracking

### DIFF
--- a/app/api/sessions/summary/route.ts
+++ b/app/api/sessions/summary/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getDailyProgress } from "@/lib/db";
+import { getUserEmail } from "@/lib/user";
+
+export const runtime = "edge";
+
+function computeStreak(activeDays: string[]): number {
+  if (activeDays.length === 0) return 0;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+  // Streak requires activity today or yesterday
+  if (activeDays[0] !== today && activeDays[0] !== yesterday) return 0;
+
+  let streak = 1;
+  for (let i = 1; i < activeDays.length; i++) {
+    const prevDate = new Date(activeDays[i - 1]);
+    const currDate = new Date(activeDays[i]);
+    const diffDays = Math.round((prevDate.getTime() - currDate.getTime()) / 86400000);
+    if (diffDays === 1) streak++;
+    else break;
+  }
+  return streak;
+}
+
+export async function GET() {
+  const userEmail = await getUserEmail();
+  const { todayCount, activeDays } = await getDailyProgress(userEmail);
+  const streak = computeStreak(activeDays);
+  return NextResponse.json({ todayCount, streak });
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import { Check, Sparkles, Wand2, BrainCircuit, RefreshCw } from "lucide-react";
+import { Check, Sparkles, Wand2, BrainCircuit, RefreshCw, Target } from "lucide-react";
 import { useSettings } from "@/lib/settings-context";
 import PageHeader from "@/components/PageHeader";
 import type { Locale } from "@/lib/i18n";
@@ -23,6 +23,7 @@ function SettingsInner() {
   const [language, setLanguage] = useState<Locale>(settings.language);
   const [aiPrompt, setAiPrompt] = useState(settings.aiPrompt);
   const [aiRefinePrompt, setAiRefinePrompt] = useState(settings.aiRefinePrompt);
+  const [dailyGoal, setDailyGoal] = useState(settings.dailyGoal ?? 20);
   const [saved, setSaved] = useState(false);
   const [geminiModel, setGeminiModel] = useState("");
   const [modelList, setModelList] = useState<string[]>([]);
@@ -35,6 +36,7 @@ function SettingsInner() {
     setLanguage(settings.language);
     setAiPrompt(settings.aiPrompt);
     setAiRefinePrompt(settings.aiRefinePrompt);
+    setDailyGoal(settings.dailyGoal ?? 20);
   }, [settings.language, settings.aiPrompt, settings.aiRefinePrompt]);
 
   // Load current gemini model from DB
@@ -61,7 +63,7 @@ function SettingsInner() {
   }
 
   async function handleSave() {
-    updateSettings({ language, aiPrompt, aiRefinePrompt });
+    updateSettings({ language, aiPrompt, aiRefinePrompt, dailyGoal });
     if (geminiModel) {
       await fetch("/api/app-settings", {
         method: "POST",
@@ -169,6 +171,44 @@ function SettingsInner() {
               {modelList.map((m) => <option key={m} value={m} />)}
             </datalist>
           )}
+        </section>
+
+        {/* Daily Goal */}
+        <section>
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1 flex items-center gap-1.5">
+            <Target size={11} className="text-emerald-500" />
+            Daily Goal
+          </h2>
+          <p className="text-xs text-gray-400 mb-3">Number of questions to complete each day</p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setDailyGoal((v) => Math.max(5, v - 5))}
+              className="w-10 h-10 rounded-xl border border-gray-200 bg-white text-gray-600 hover:bg-gray-50 text-lg font-medium transition-colors"
+            >
+              −
+            </button>
+            <input
+              type="number"
+              min={5}
+              max={200}
+              step={5}
+              value={dailyGoal}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10);
+                if (!isNaN(v) && v >= 5 && v <= 200) setDailyGoal(v);
+              }}
+              className="w-20 text-center rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm font-semibold text-gray-900 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent"
+            />
+            <button
+              type="button"
+              onClick={() => setDailyGoal((v) => Math.min(200, v + 5))}
+              className="w-10 h-10 rounded-xl border border-gray-200 bg-white text-gray-600 hover:bg-gray-50 text-lg font-medium transition-colors"
+            >
+              ＋
+            </button>
+            <span className="text-xs text-gray-400 ml-1">questions / day</span>
+          </div>
         </section>
 
         {/* Save */}

--- a/components/ExamListClient.tsx
+++ b/components/ExamListClient.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronRight, RotateCcw, Upload, Download, Plus, X, User, Search } from "lucide-react";
+import { ChevronRight, RotateCcw, Upload, Download, Plus, X, User, Search, Flame } from "lucide-react";
 import Link from "next/link";
 import type { ExamMeta, QuizStats } from "@/lib/types";
+import { useSettings } from "@/lib/settings-context";
 import PageHeader from "./PageHeader";
 import OnboardingGuide from "./OnboardingGuide";
 import { useSettings } from "@/lib/settings-context";
@@ -68,8 +69,16 @@ export default function ExamListClient({ exams: initialExams }: Props) {
   );
   const [isDragging, setIsDragging] = useState(false);
   const [showAdd, setShowAdd] = useState(false);
+  const [dailyProgress, setDailyProgress] = useState<{ todayCount: number; streak: number } | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
   const dragCountRef = useRef(0);
+
+  useEffect(() => {
+    fetch("/api/sessions/summary")
+      .then((r) => r.json() as Promise<{ todayCount: number; streak: number }>)
+      .then(setDailyProgress)
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     const map: typeof statsMap = {};
@@ -217,6 +226,40 @@ export default function ExamListClient({ exams: initialExams }: Props) {
           ))}
         </div>
       </div>
+
+      {/* Daily progress banner */}
+      {dailyProgress && (dailyProgress.todayCount > 0 || dailyProgress.streak > 0) && (() => {
+        const goal = settings.dailyGoal ?? 20;
+        const { todayCount, streak } = dailyProgress;
+        const pct = Math.min(100, Math.round((todayCount / goal) * 100));
+        const done = todayCount >= goal;
+        return (
+          <div className="px-4 sm:px-8 pb-3 max-w-3xl mx-auto w-full">
+            <div className={`flex items-center gap-3 px-4 py-2.5 rounded-xl border ${done ? "bg-emerald-50 border-emerald-200" : "bg-white border-gray-200"}`}>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between mb-1">
+                  <span className={`text-xs font-semibold ${done ? "text-emerald-700" : "text-gray-500"}`}>
+                    Today: {todayCount}/{goal}
+                  </span>
+                  {done && <span className="text-xs text-emerald-600 font-medium">Goal reached</span>}
+                </div>
+                <div className="h-1 bg-gray-100 rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full transition-all ${done ? "bg-emerald-500" : "bg-gray-400"}`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+              {streak > 0 && (
+                <div className={`flex items-center gap-1 shrink-0 ${streak >= 7 ? "text-amber-500" : "text-gray-400"}`}>
+                  <Flame size={13} strokeWidth={2} />
+                  <span className="text-xs font-semibold tabular-nums">{streak}d</span>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })()}
 
       <div className="flex-1 px-4 sm:px-8 pb-6 overflow-y-auto">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-3xl mx-auto">

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -463,6 +463,38 @@ export async function getSessionsByExam(
   }));
 }
 
+// ── Daily progress ──────────────────────────────────────────────────────────
+
+export async function getDailyProgress(userEmail: string): Promise<{
+  todayCount: number;
+  activeDays: string[]; // YYYY-MM-DD strings, descending, max 90
+}> {
+  const db = getDB();
+  if (!db) return { todayCount: 0, activeDays: [] };
+
+  const todayRow = await db
+    .prepare(
+      `SELECT COALESCE(SUM(question_count), 0) as cnt
+       FROM sessions WHERE user_email = ? AND date(started_at) = date('now')`
+    )
+    .bind(userEmail)
+    .first<{ cnt: number }>();
+
+  const daysResult = await db
+    .prepare(
+      `SELECT DISTINCT date(started_at) as day
+       FROM sessions WHERE user_email = ?
+       ORDER BY day DESC LIMIT 90`
+    )
+    .bind(userEmail)
+    .all<{ day: string }>();
+
+  return {
+    todayCount: todayRow?.cnt ?? 0,
+    activeDays: (daysResult.results ?? []).map((r) => r.day),
+  };
+}
+
 // ── App settings ───────────────────────────────────────────────────────────
 
 export async function getSetting(key: string): Promise<string | null> {


### PR DESCRIPTION
## Summary
- Adds daily question goal (default 20, configurable in Settings) with progress bar on home screen
- Shows consecutive-day streak badge next to today's progress
- New `/api/sessions/summary` endpoint aggregates today's session count and active days for streak calculation
- `UserSettings` gains `dailyGoal` field; Settings page gets a ±5 stepper

## Changes
- `lib/types.ts` — add `dailyGoal` to `UserSettings`
- `lib/db.ts` — add `getDailyProgress()` returning today's count + active day list
- `app/api/sessions/summary/route.ts` — new edge route
- `components/ExamListClient.tsx` — today's progress banner with streak badge
- `app/settings/page.tsx` — Daily Goal stepper (min 5, max 200)

## Test plan
- [ ] Open home screen — banner hidden when no sessions today (expected in local dev without D1)
- [ ] Complete questions in quiz mode — banner appears with count and progress bar
- [ ] Change Daily Goal in Settings → saved and reflected in banner
- [ ] Streak increments when studying on consecutive days

🤖 Generated with [Claude Code](https://claude.com/claude-code)