### PR TITLE
fix: revert local-exams/local-questions routes to edge runtime

### DIFF
--- a/app/api/local-exams/route.ts
+++ b/app/api/local-exams/route.ts
@@ -1,4 +1,4 @@
-export const runtime = "nodejs";
+export const runtime = "edge";
 
 import { NextResponse } from "next/server";
 

--- a/app/api/local-questions/[examId]/route.ts
+++ b/app/api/local-questions/[examId]/route.ts
@@ -1,4 +1,4 @@
-export const runtime = "nodejs";
+export const runtime = "edge";
 
 import { NextResponse } from "next/server";
 


### PR DESCRIPTION
## Summary
- Reverts `runtime = 'nodejs'` → `runtime = 'edge'` for `/api/local-exams` and `/api/local-questions/[examId]`
- Cloudflare Pages requires edge runtime for all routes — nodejs runtime causes build failure
- These routes early-return `[]` when `DEPLOY_TARGET !== "local"`, so Node.js CSV imports are never reached in production

## Root cause
PR #24 changed these routes to `nodejs` to fix a local dev issue with `process.cwd()`, but Cloudflare Pages only supports Edge Runtime.

## Test plan
- [ ] Cloudflare Pages build succeeds
- [ ] Local dev: `/api/local-exams` still returns exam list (DEPLOY_TARGET=local)
- [ ] Production: routes return `[]` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)