### PR TITLE
feat: migrate localStorage to server-side user data

### DIFF
--- a/app/api/scores/route.ts
+++ b/app/api/scores/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getScores, saveScore, addSessionAnswer } from "@/lib/db";
+import { getScores, getAllScores, saveScore, addSessionAnswer } from "@/lib/db";
 import { getUserEmail } from "@/lib/user";
 
 export const runtime = "edge";
@@ -7,9 +7,14 @@ export const runtime = "edge";
 
 export async function GET(req: NextRequest) {
   const examId = req.nextUrl.searchParams.get("examId");
-  if (!examId) return NextResponse.json({ error: "examId required" }, { status: 400 });
-
   const userEmail = await getUserEmail();
+
+  if (!examId) {
+    // Return all exams' scores grouped by examId
+    const statsMap = await getAllScores(userEmail);
+    return NextResponse.json({ statsMap });
+  }
+
   const stats = await getScores(userEmail, examId);
   return NextResponse.json(stats);
 }

--- a/app/api/snapshots/route.ts
+++ b/app/api/snapshots/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSnapshots, saveSnapshot } from "@/lib/db";
+import { getUserEmail } from "@/lib/user";
+
+export const runtime = "edge";
+
+export async function GET(req: NextRequest) {
+  const examId = req.nextUrl.searchParams.get("examId") ?? undefined;
+  const userEmail = await getUserEmail();
+  const snapshots = await getSnapshots(userEmail, examId);
+  return NextResponse.json({ snapshots });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json() as {
+    examId: string;
+    ts: number;
+    correct: number;
+    total: number;
+    accuracy: number;
+  };
+  if (!body.examId || body.ts == null) {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  }
+  const userEmail = await getUserEmail();
+  await saveSnapshot(userEmail, body.examId, body.ts, body.correct, body.total, body.accuracy);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/user-settings/route.ts
+++ b/app/api/user-settings/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllUserSettings, setUserSettings } from "@/lib/db";
+import { getUserEmail } from "@/lib/user";
+import type { UserSettings } from "@/lib/types";
+
+export const runtime = "edge";
+
+export async function GET() {
+  const userEmail = await getUserEmail();
+  const settings = await getAllUserSettings(userEmail);
+  return NextResponse.json({ settings });
+}
+
+export async function PUT(req: NextRequest) {
+  const body = await req.json() as Partial<UserSettings>;
+  const userEmail = await getUserEmail();
+  await setUserSettings(userEmail, body);
+  return NextResponse.json({ ok: true });
+}

--- a/components/ExamListClient.tsx
+++ b/components/ExamListClient.tsx
@@ -4,24 +4,13 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronRight, RotateCcw, Upload, Download, Plus, X, User, Search, Flame } from "lucide-react";
 import Link from "next/link";
-import type { ExamMeta, QuizStats } from "@/lib/types";
+import type { ExamMeta } from "@/lib/types";
 import { useSettings } from "@/lib/settings-context";
 import PageHeader from "./PageHeader";
 import OnboardingGuide from "./OnboardingGuide";
 
 interface Props {
   exams: ExamMeta[];
-}
-
-function loadStats(examId: string): QuizStats {
-  try {
-    const raw = JSON.parse(localStorage.getItem(`quiz-stats-${examId}`) ?? "{}");
-    const out: QuizStats = {};
-    for (const [k, v] of Object.entries(raw)) {
-      if (v === 0 || v === 1) out[k] = v as 0 | 1;
-    }
-    return out;
-  } catch { return {}; }
 }
 
 type UploadStatus = "idle" | "uploading" | "done" | "error";
@@ -80,20 +69,43 @@ export default function ExamListClient({ exams: initialExams }: Props) {
   }, []);
 
   useEffect(() => {
-    const map: typeof statsMap = {};
-    for (const exam of exams) {
-      const stats = loadStats(exam.id);
-      const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
-      const correct = keys.filter((k) => stats[k] === 1).length;
-      const wrongCount = keys.filter((k) => stats[k] === 0).length;
-      map[exam.id] = {
-        pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
-        answered: keys.length,
-        total: exam.questionCount,
-        wrongCount,
-      };
-    }
-    setStatsMap(map);
+    fetch("/api/scores")
+      .then((r) => r.json() as Promise<{ statsMap: Record<string, Record<string, 0 | 1>> }>)
+      .then(({ statsMap: remote }) => {
+        const map: typeof statsMap = {};
+        for (const exam of exams) {
+          const stats = remote[exam.id] ?? {};
+          const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
+          const correct = keys.filter((k) => stats[k] === 1).length;
+          const wrongCount = keys.filter((k) => stats[k] === 0).length;
+          map[exam.id] = {
+            pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
+            answered: keys.length,
+            total: exam.questionCount,
+            wrongCount,
+          };
+        }
+        setStatsMap(map);
+      })
+      .catch(() => {
+        // Fallback: localStorage
+        const map: typeof statsMap = {};
+        for (const exam of exams) {
+          try {
+            const raw = JSON.parse(localStorage.getItem(`quiz-stats-${exam.id}`) ?? "{}");
+            const keys = Object.keys(raw).filter((k) => raw[k] === 0 || raw[k] === 1);
+            const correct = keys.filter((k) => raw[k] === 1).length;
+            const wrongCount = keys.filter((k) => raw[k] === 0).length;
+            map[exam.id] = {
+              pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
+              answered: keys.length,
+              total: exam.questionCount,
+              wrongCount,
+            };
+          } catch { map[exam.id] = { pct: null, answered: 0, total: exam.questionCount, wrongCount: 0 }; }
+        }
+        setStatsMap(map);
+      });
   }, [exams]);
 
   const processFiles = useCallback(async (files: File[]) => {

--- a/components/ExamSelectClient.tsx
+++ b/components/ExamSelectClient.tsx
@@ -3,23 +3,12 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { RotateCcw, ChevronRight, Download, Upload, Plus, X } from "lucide-react";
-import type { ExamMeta, QuizStats } from "@/lib/types";
+import type { ExamMeta } from "@/lib/types";
 import PageHeader from "./PageHeader";
 
 interface Props {
   exams: ExamMeta[];
   mode: "quiz" | "review" | "answers";
-}
-
-function loadStats(examId: string): QuizStats {
-  try {
-    const raw = JSON.parse(localStorage.getItem(`quiz-stats-${examId}`) ?? "{}");
-    const out: QuizStats = {};
-    for (const [k, v] of Object.entries(raw)) {
-      if (v === 0 || v === 1) out[k] = v as 0 | 1;
-    }
-    return out;
-  } catch { return {}; }
 }
 
 type UploadStatus = "idle" | "uploading" | "done" | "error";
@@ -60,20 +49,43 @@ export default function ExamSelectClient({ exams: initialExams, mode }: Props) {
   const dragCountRef = useRef(0);
 
   useEffect(() => {
-    const map: typeof statsMap = {};
-    for (const exam of exams) {
-      const stats = loadStats(exam.id);
-      const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
-      const correct = keys.filter((k) => stats[k] === 1).length;
-      const wrongCount = keys.filter((k) => stats[k] === 0).length;
-      map[exam.id] = {
-        pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
-        answered: keys.length,
-        total: exam.questionCount,
-        wrongCount,
-      };
-    }
-    setStatsMap(map);
+    fetch("/api/scores")
+      .then((r) => r.json() as Promise<{ statsMap: Record<string, Record<string, 0 | 1>> }>)
+      .then(({ statsMap: remote }) => {
+        const map: typeof statsMap = {};
+        for (const exam of exams) {
+          const stats = remote[exam.id] ?? {};
+          const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
+          const correct = keys.filter((k) => stats[k] === 1).length;
+          const wrongCount = keys.filter((k) => stats[k] === 0).length;
+          map[exam.id] = {
+            pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
+            answered: keys.length,
+            total: exam.questionCount,
+            wrongCount,
+          };
+        }
+        setStatsMap(map);
+      })
+      .catch(() => {
+        // Fallback: localStorage
+        const map: typeof statsMap = {};
+        for (const exam of exams) {
+          try {
+            const raw = JSON.parse(localStorage.getItem(`quiz-stats-${exam.id}`) ?? "{}");
+            const keys = Object.keys(raw).filter((k) => raw[k] === 0 || raw[k] === 1);
+            const correct = keys.filter((k) => raw[k] === 1).length;
+            const wrongCount = keys.filter((k) => raw[k] === 0).length;
+            map[exam.id] = {
+              pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
+              answered: keys.length,
+              total: exam.questionCount,
+              wrongCount,
+            };
+          } catch { map[exam.id] = { pct: null, answered: 0, total: exam.questionCount, wrongCount: 0 }; }
+        }
+        setStatsMap(map);
+      });
   }, [exams]);
 
   const processFiles = useCallback(async (files: File[]) => {

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef, useCallback } from "react";
 import { Download, Upload, Plus, CheckCircle2, XCircle, Loader2, FilePlus } from "lucide-react";
-import type { ExamMeta, QuizStats } from "@/lib/types";
+import type { ExamMeta } from "@/lib/types";
 import ExamCard from "./ExamCard";
 
 const CSV_TEMPLATE = `duplicate,#,question,choices,answer,explanation,source
@@ -26,14 +26,6 @@ interface Props {
 
 type Mode = "quiz" | "review";
 type UploadStatus = "idle" | "uploading" | "done" | "error";
-
-function loadAllStats(examId: string): QuizStats {
-  try {
-    return JSON.parse(localStorage.getItem(`quiz-stats-${examId}`) ?? "{}");
-  } catch {
-    return {};
-  }
-}
 
 async function uploadFile(file: File, appendTo?: string): Promise<{ exam: ExamMeta; appended?: number }> {
   const formData = new FormData();
@@ -59,17 +51,37 @@ export default function HomeClient({ exams: initialExams }: Props) {
   const dragCountRef = useRef(0);
 
   useEffect(() => {
-    const map: typeof statsMap = {};
-    for (const exam of exams) {
-      const stats = loadAllStats(exam.id);
-      const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
-      map[exam.id] = {
-        answered: keys.length,
-        total: exam.questionCount,
-        correct: keys.filter((k) => stats[k] === 1).length,
-      };
-    }
-    setStatsMap(map);
+    fetch("/api/scores")
+      .then((r) => r.json() as Promise<{ statsMap: Record<string, Record<string, 0 | 1>> }>)
+      .then(({ statsMap: remote }) => {
+        const map: typeof statsMap = {};
+        for (const exam of exams) {
+          const stats = remote[exam.id] ?? {};
+          const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
+          map[exam.id] = {
+            answered: keys.length,
+            total: exam.questionCount,
+            correct: keys.filter((k) => stats[k] === 1).length,
+          };
+        }
+        setStatsMap(map);
+      })
+      .catch(() => {
+        // Fallback: localStorage
+        const map: typeof statsMap = {};
+        for (const exam of exams) {
+          try {
+            const raw = JSON.parse(localStorage.getItem(`quiz-stats-${exam.id}`) ?? "{}");
+            const keys = Object.keys(raw).filter((k) => raw[k] === 0 || raw[k] === 1);
+            map[exam.id] = {
+              answered: keys.length,
+              total: exam.questionCount,
+              correct: keys.filter((k) => raw[k] === 1).length,
+            };
+          } catch { map[exam.id] = { answered: 0, total: exam.questionCount, correct: 0 }; }
+        }
+        setStatsMap(map);
+      });
   }, [exams]);
 
   const processFiles = useCallback(async (files: File[]) => {

--- a/components/ProfileClient.tsx
+++ b/components/ProfileClient.tsx
@@ -7,21 +7,10 @@ import type { ExamMeta, QuizStats, CategoryStat, ExamSnapshot, SessionRecord } f
 import PageHeader from "./PageHeader";
 import ExamTrendChart from "./ExamTrendChart";
 import CategoryChart from "./CategoryChart";
-import { getAllSnapshots } from "@/lib/snapshots";
+import { loadServerSnapshots } from "@/lib/snapshots";
 
 interface Props {
   exams: ExamMeta[];
-}
-
-function loadStats(examId: string): QuizStats {
-  try {
-    const raw = JSON.parse(localStorage.getItem(`quiz-stats-${examId}`) ?? "{}");
-    const out: QuizStats = {};
-    for (const [k, v] of Object.entries(raw)) {
-      if (v === 0 || v === 1) out[k] = v as 0 | 1;
-    }
-    return out;
-  } catch { return {}; }
 }
 
 interface ExamStats {
@@ -41,21 +30,47 @@ export default function ProfileClient({ exams }: Props) {
   const [sessionCache, setSessionCache] = useState<Record<string, SessionRecord[]>>({});
 
   useEffect(() => {
-    const map: Record<string, ExamStats> = {};
-    for (const exam of exams) {
-      const stats = loadStats(exam.id);
-      const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
-      const correct = keys.filter((k) => stats[k] === 1).length;
-      const wrongCount = keys.filter((k) => stats[k] === 0).length;
-      map[exam.id] = {
-        pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
-        answered: keys.length,
-        total: exam.questionCount,
-        wrongCount,
-      };
-    }
-    setStatsMap(map);
-    setSnapshotsMap(getAllSnapshots());
+    // Load stats from server (all exams at once)
+    fetch("/api/scores")
+      .then((r) => r.json() as Promise<{ statsMap: Record<string, QuizStats> }>)
+      .then(({ statsMap: remote }) => {
+        const map: Record<string, ExamStats> = {};
+        for (const exam of exams) {
+          const stats = remote[exam.id] ?? {};
+          const keys = Object.keys(stats).filter((k) => stats[k] === 0 || stats[k] === 1);
+          const correct = keys.filter((k) => stats[k] === 1).length;
+          const wrongCount = keys.filter((k) => stats[k] === 0).length;
+          map[exam.id] = {
+            pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
+            answered: keys.length,
+            total: exam.questionCount,
+            wrongCount,
+          };
+        }
+        setStatsMap(map);
+      })
+      .catch(() => {
+        // Fallback: read from localStorage
+        const map: Record<string, ExamStats> = {};
+        for (const exam of exams) {
+          try {
+            const raw = JSON.parse(localStorage.getItem(`quiz-stats-${exam.id}`) ?? "{}");
+            const keys = Object.keys(raw).filter((k) => raw[k] === 0 || raw[k] === 1);
+            const correct = keys.filter((k) => raw[k] === 1).length;
+            const wrongCount = keys.filter((k) => raw[k] === 0).length;
+            map[exam.id] = {
+              pct: keys.length > 0 ? Math.round((correct / exam.questionCount) * 100) : null,
+              answered: keys.length,
+              total: exam.questionCount,
+              wrongCount,
+            };
+          } catch { map[exam.id] = { pct: null, answered: 0, total: exam.questionCount, wrongCount: 0 }; }
+        }
+        setStatsMap(map);
+      });
+
+    // Load snapshots from server
+    loadServerSnapshots().then(setSnapshotsMap).catch(() => {});
   }, [exams]);
 
   function handleExamClick(examId: string) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
-import type { CategoryStat, Choice, ExamMeta, Question, QuestionHistoryEntry, QuizStats, SessionRecord } from "./types";
+import type { CategoryStat, Choice, ExamMeta, ExamSnapshot, Question, QuestionHistoryEntry, QuizStats, SessionRecord, UserSettings } from "./types";
+import { DEFAULT_USER_SETTINGS } from "./types";
 import { getRequestContext } from "@cloudflare/next-on-pages";
 
 // Minimal D1 type stub – replaced by @cloudflare/workers-types after npm install
@@ -566,6 +567,156 @@ export async function getDueCount(userEmail: string, examId: string): Promise<nu
     .first<{ cnt: number }>();
 
   return row?.cnt ?? 0;
+}
+
+// ── All scores (cross-exam) ─────────────────────────────────────────────────
+
+export async function getAllScores(userEmail: string): Promise<Record<string, QuizStats>> {
+  const db = getDB();
+  if (!db) return {};
+
+  const result = await db
+    .prepare("SELECT question_id, last_correct FROM scores WHERE user_email = ?")
+    .bind(userEmail)
+    .all<{ question_id: string; last_correct: number }>();
+
+  const statsMap: Record<string, QuizStats> = {};
+  for (const row of result.results ?? []) {
+    const sep = row.question_id.indexOf("__");
+    if (sep < 0) continue;
+    const examId = row.question_id.slice(0, sep);
+    const num = row.question_id.slice(sep + 2);
+    if (!statsMap[examId]) statsMap[examId] = {};
+    statsMap[examId][num] = row.last_correct as 0 | 1;
+  }
+  return statsMap;
+}
+
+// ── User settings ───────────────────────────────────────────────────────────
+
+export async function getAllUserSettings(userEmail: string): Promise<UserSettings> {
+  const db = getDB();
+  if (!db) return DEFAULT_USER_SETTINGS;
+
+  const result = await db
+    .prepare("SELECT key, value FROM user_settings WHERE user_email = ?")
+    .bind(userEmail)
+    .all<{ key: string; value: string }>();
+
+  if (!result.results?.length) return DEFAULT_USER_SETTINGS;
+
+  const raw: Partial<UserSettings> = {};
+  for (const row of result.results) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (raw as any)[row.key] = row.key === "dailyGoal" ? Number(row.value) : row.value;
+  }
+  const merged: UserSettings = { ...DEFAULT_USER_SETTINGS, ...raw };
+  if (!merged.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
+  if (!merged.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+  return merged;
+}
+
+export async function setUserSettings(
+  userEmail: string,
+  settings: Partial<UserSettings>
+): Promise<void> {
+  const db = getDB();
+  if (!db) return;
+
+  for (const [key, value] of Object.entries(settings)) {
+    await db
+      .prepare(
+        `INSERT INTO user_settings (user_email, key, value, updated_at)
+         VALUES (?, ?, ?, datetime('now'))
+         ON CONFLICT(user_email, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+      )
+      .bind(userEmail, key, String(value))
+      .run();
+  }
+}
+
+// ── User snapshots ──────────────────────────────────────────────────────────
+
+export async function getSnapshots(
+  userEmail: string,
+  examId?: string
+): Promise<Record<string, ExamSnapshot[]>> {
+  const db = getDB();
+  if (!db) return {};
+
+  const result = examId
+    ? await db
+        .prepare(
+          "SELECT exam_id, ts, correct, total, accuracy FROM user_snapshots WHERE user_email = ? AND exam_id = ? ORDER BY ts ASC"
+        )
+        .bind(userEmail, examId)
+        .all<{ exam_id: string; ts: number; correct: number; total: number; accuracy: number }>()
+    : await db
+        .prepare(
+          "SELECT exam_id, ts, correct, total, accuracy FROM user_snapshots WHERE user_email = ? ORDER BY ts ASC"
+        )
+        .bind(userEmail)
+        .all<{ exam_id: string; ts: number; correct: number; total: number; accuracy: number }>();
+
+  const map: Record<string, ExamSnapshot[]> = {};
+  for (const row of result.results ?? []) {
+    if (!map[row.exam_id]) map[row.exam_id] = [];
+    map[row.exam_id].push({ ts: row.ts, correct: row.correct, total: row.total, accuracy: row.accuracy });
+  }
+  return map;
+}
+
+export async function saveSnapshot(
+  userEmail: string,
+  examId: string,
+  ts: number,
+  correct: number,
+  total: number,
+  accuracy: number
+): Promise<void> {
+  const db = getDB();
+  if (!db) return;
+
+  // Check if there's already a snapshot from today (by UTC date)
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const todayTs = todayStart.getTime();
+  const tomorrowTs = todayTs + 86400000;
+
+  const existing = await db
+    .prepare(
+      "SELECT id FROM user_snapshots WHERE user_email = ? AND exam_id = ? AND ts >= ? AND ts < ?"
+    )
+    .bind(userEmail, examId, todayTs, tomorrowTs)
+    .first<{ id: number }>();
+
+  if (existing) {
+    await db
+      .prepare(
+        "UPDATE user_snapshots SET ts = ?, correct = ?, total = ?, accuracy = ? WHERE id = ?"
+      )
+      .bind(ts, correct, total, accuracy, existing.id)
+      .run();
+  } else {
+    await db
+      .prepare(
+        `INSERT INTO user_snapshots (user_email, exam_id, ts, correct, total, accuracy)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .bind(userEmail, examId, ts, correct, total, accuracy)
+      .run();
+
+    // Keep only last 60 snapshots per exam
+    await db
+      .prepare(
+        `DELETE FROM user_snapshots WHERE user_email = ? AND exam_id = ? AND id NOT IN (
+           SELECT id FROM user_snapshots WHERE user_email = ? AND exam_id = ?
+           ORDER BY ts DESC LIMIT 60
+         )`
+      )
+      .bind(userEmail, examId, userEmail, examId)
+      .run();
+  }
 }
 
 // ── App settings ───────────────────────────────────────────────────────────

--- a/lib/settings-context.tsx
+++ b/lib/settings-context.tsx
@@ -19,25 +19,43 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [settings, setSettings] = useState<UserSettings>(DEFAULT_USER_SETTINGS);
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as Partial<UserSettings>;
-        const merged = { ...DEFAULT_USER_SETTINGS, ...parsed };
-        // Empty prompt strings mean "not yet customized" — use the default
-        if (!parsed.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
-        if (!parsed.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+    // Load from API first; fall back to localStorage
+    fetch("/api/user-settings")
+      .then((r) => r.json() as Promise<{ settings: UserSettings }>)
+      .then(({ settings: remote }) => {
+        // Merge defaults, remote wins
+        const merged: UserSettings = { ...DEFAULT_USER_SETTINGS, ...remote };
+        if (!merged.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
+        if (!merged.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
         setSettings(merged);
-      }
-    } catch {
-      // ignore
-    }
+        // Sync to localStorage as cache
+        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch { /* ignore */ }
+      })
+      .catch(() => {
+        // API unavailable — fall back to localStorage
+        try {
+          const raw = localStorage.getItem(STORAGE_KEY);
+          if (raw) {
+            const parsed = JSON.parse(raw) as Partial<UserSettings>;
+            const merged = { ...DEFAULT_USER_SETTINGS, ...parsed };
+            if (!parsed.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
+            if (!parsed.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+            setSettings(merged);
+          }
+        } catch { /* ignore */ }
+      });
   }, []);
 
   function updateSettings(patch: Partial<UserSettings>) {
     setSettings((prev) => {
       const next = { ...prev, ...patch };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
+      // Fire-and-forget save to server
+      fetch("/api/user-settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      }).catch(() => {});
       return next;
     });
   }

--- a/lib/snapshots.ts
+++ b/lib/snapshots.ts
@@ -37,7 +37,7 @@ export function recordDailySnapshot(
 
   const last = list[list.length - 1];
   if (last && new Date(last.ts).toDateString() === today) {
-    list[list.length - 1] = snap; // overwrite today's entry
+    list[list.length - 1] = snap;
   } else {
     list.push(snap);
     if (list.length > 60) list.splice(0, list.length - 60);
@@ -45,4 +45,29 @@ export function recordDailySnapshot(
 
   all[examId] = list;
   saveAllSnapshots(all);
+
+  // Fire-and-forget save to server
+  fetch("/api/snapshots", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ examId, ts: snap.ts, correct: snap.correct, total: snap.total, accuracy: snap.accuracy }),
+  }).catch(() => {});
+}
+
+/** Load snapshots from server (API), merged with localStorage (API wins). */
+export async function loadServerSnapshots(examId?: string): Promise<Record<string, ExamSnapshot[]>> {
+  try {
+    const url = examId
+      ? `/api/snapshots?examId=${encodeURIComponent(examId)}`
+      : "/api/snapshots";
+    const res = await fetch(url);
+    if (!res.ok) throw new Error("fetch failed");
+    const { snapshots } = await res.json() as { snapshots: Record<string, ExamSnapshot[]> };
+    // Merge with localStorage (server wins)
+    const local = loadAllSnapshots();
+    const merged: Record<string, ExamSnapshot[]> = { ...local, ...snapshots };
+    return merged;
+  } catch {
+    return loadAllSnapshots();
+  }
 }

--- a/migrations/0009_user_data.sql
+++ b/migrations/0009_user_data.sql
@@ -1,0 +1,23 @@
+-- User settings: language, AI prompts, daily goal, etc.
+CREATE TABLE IF NOT EXISTS user_settings (
+  user_email TEXT NOT NULL,
+  key        TEXT NOT NULL,
+  value      TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_email, key)
+);
+
+-- Daily progress snapshots per exam per user
+CREATE TABLE IF NOT EXISTS user_snapshots (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_email TEXT NOT NULL,
+  exam_id    TEXT NOT NULL,
+  ts         INTEGER NOT NULL,
+  correct    INTEGER NOT NULL,
+  total      INTEGER NOT NULL,
+  accuracy   REAL NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_snapshots_user_exam
+  ON user_snapshots(user_email, exam_id);


### PR DESCRIPTION
## Summary

- Add `user_settings` and `user_snapshots` tables (migration 0009) to persist data across devices
- `GET /api/scores` now returns all exams at once when `examId` is omitted
- New `GET/PUT /api/user-settings` endpoint for language and AI prompt settings
- New `GET/POST /api/snapshots` endpoint for daily progress snapshots
- `ProfileClient`, `ExamListClient`, `HomeClient`, `ExamSelectClient` now fetch stats from API (localStorage as fallback)
- `SettingsProvider` loads from API on mount and writes through to both API and localStorage
- `recordDailySnapshot()` also persists to server via fire-and-forget POST

## Test plan

- [ ] Quiz stats appear correctly on exam list and profile pages
- [ ] Stats persist across different browsers/devices for the same user
- [ ] User settings (language) sync across devices
- [ ] Progress snapshots saved server-side and visible in profile trend chart
- [ ] localStorage fallback works when API is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)