### PR TITLE
fix: restore 4-language selector as unified settings.language

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -5,6 +5,14 @@ import { useSearchParams } from "next/navigation";
 import { Check, Sparkles, Wand2, BrainCircuit, RefreshCw, Target } from "lucide-react";
 import { useSettings } from "@/lib/settings-context";
 import PageHeader from "@/components/PageHeader";
+import type { Locale } from "@/lib/i18n";
+
+const LANGUAGES: { value: Locale; label: string; native: string }[] = [
+  { value: "en", label: "English", native: "English" },
+  { value: "ja", label: "Japanese", native: "日本語" },
+  { value: "zh", label: "Chinese (Simplified)", native: "中文（简体）" },
+  { value: "ko", label: "Korean", native: "한국어" },
+];
 
 function SettingsInner() {
   const searchParams = useSearchParams();
@@ -12,6 +20,7 @@ function SettingsInner() {
   const returnTo = raw.startsWith("/") ? raw : "/";
 
   const { settings, updateSettings, t } = useSettings();
+  const [language, setLanguage] = useState<Locale>(settings.language);
   const [aiPrompt, setAiPrompt] = useState(settings.aiPrompt);
   const [aiRefinePrompt, setAiRefinePrompt] = useState(settings.aiRefinePrompt);
   const [dailyGoal, setDailyGoal] = useState(settings.dailyGoal ?? 20);
@@ -24,10 +33,11 @@ function SettingsInner() {
 
   // Sync local state when settings load from localStorage
   useEffect(() => {
+    setLanguage(settings.language);
     setAiPrompt(settings.aiPrompt);
     setAiRefinePrompt(settings.aiRefinePrompt);
     setDailyGoal(settings.dailyGoal ?? 20);
-  }, [settings.aiPrompt, settings.aiRefinePrompt]);
+  }, [settings.language, settings.aiPrompt, settings.aiRefinePrompt]);
 
   // Load current gemini model from DB
   useEffect(() => {
@@ -53,7 +63,7 @@ function SettingsInner() {
   }
 
   async function handleSave() {
-    updateSettings({ aiPrompt, aiRefinePrompt, dailyGoal });
+    updateSettings({ language, aiPrompt, aiRefinePrompt, dailyGoal });
     if (geminiModel) {
       await fetch("/api/app-settings", {
         method: "POST",
@@ -69,6 +79,30 @@ function SettingsInner() {
     <div className="min-h-screen bg-[#f8f9fb] flex flex-col">
       <PageHeader back={{ href: returnTo }} title={t("settings")} hideSettingsIcon />
       <main className="flex-1 px-4 sm:px-8 py-8 max-w-xl mx-auto w-full space-y-8">
+
+        {/* Language */}
+        <section>
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+            {t("languageLabel")}
+          </h2>
+          <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden divide-y divide-gray-100">
+            {LANGUAGES.map((lang) => (
+              <button
+                key={lang.value}
+                onClick={() => { setLanguage(lang.value); updateSettings({ language: lang.value }); }}
+                className="w-full flex items-center justify-between px-4 py-3.5 hover:bg-gray-50 transition-colors text-left"
+              >
+                <div>
+                  <span className="text-sm font-medium text-gray-900">{lang.native}</span>
+                  <span className="ml-2 text-xs text-gray-400">{lang.label}</span>
+                </div>
+                {language === lang.value && (
+                  <Check size={15} className="text-blue-500 shrink-0" strokeWidth={2.5} />
+                )}
+              </button>
+            ))}
+          </div>
+        </section>
 
         {/* AI Explain Prompt */}
         <section>

--- a/components/ExamListClient.tsx
+++ b/components/ExamListClient.tsx
@@ -224,15 +224,15 @@ export default function ExamListClient({ exams: initialExams }: Props) {
           )}
         </div>
         <div className="flex items-center bg-gray-100 rounded-lg p-0.5 gap-0.5 shrink-0">
-          {(["ja", "en"] as const).map((lang) => (
+          {(["ja", "en", "zh", "ko"] as const).map((lang) => (
             <button
               key={lang}
               onClick={() => updateSettings({ language: lang })}
               className={`text-xs font-medium px-2.5 py-1 rounded-md transition-colors ${
-                langFilter === lang ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
+                settings.language === lang ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
               }`}
             >
-              {lang === "ja" ? "JP" : "EN"}
+              {lang === "ja" ? "JP" : lang === "en" ? "EN" : lang === "zh" ? "ZH" : "KO"}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Restore en/ja/zh/ko language selector in Settings page (removed by #30)
- ExamListClient filter buttons now show JP/EN/ZH/KO and update `settings.language` (single source of truth)
- `langFilter` derived from `settings.language`: ja→JP exams, en→EN exams, zh/ko→all exams
- `uploadLang` also derived from `settings.language`

## Root cause

PR #30 introduced two regressions:
1. Removed 4-language selector from Settings page
2. Changed ExamListClient filter to only JP/EN, breaking zh/ko selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)