### PR TITLE
fix: show question version in quiz mode position indicator

### DIFF
--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -716,7 +716,10 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
         `}>
           {/* Position indicator */}
           <div className="shrink-0 px-4 sm:px-8 pt-4 sm:pt-5 pb-3 flex items-center justify-between">
-            <span className="text-xs tabular-nums text-gray-400">Q{currentIndex + 1}/{filteredQuestions.length}</span>
+            <span className="text-xs tabular-nums text-gray-400">
+              Q{currentIndex + 1}/{filteredQuestions.length}
+              <span className="ml-2 text-gray-300">v{q.version}</span>
+            </span>
             <button
               onClick={() => setCreateMode(true)}
               className="p-1 text-gray-300 hover:text-emerald-500 transition-colors"


### PR DESCRIPTION
## Summary
- Added `v{n}` version badge to the position indicator (`Q1/50 v2`) in quiz and flashcard modes
- Consistent with the version display already present in Answer Sheet (AnswersClient)

## Test plan
- [ ] Open any exam in quiz mode — confirm `v1` (or current version) appears next to `Q1/50`
- [ ] Same in flashcard mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)