### PR TITLE
fix: trigger TTS in all modes and on audioMode toggle

### DIFF
--- a/components/AnswersClient.tsx
+++ b/components/AnswersClient.tsx
@@ -29,14 +29,14 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
   const { settings, updateSettings, t } = useSettings();
   const { speak, stop } = useAudio();
 
-  // Auto-play when question changes
+  // Auto-play when question changes or audio is toggled on
   useEffect(() => {
     const q = questions[currentIndex];
     if (!q) return;
     speak(buildAnswerText(q, settings.language));
     return () => { stop(); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentIndex]);
+  }, [currentIndex, settings.audioMode]);
 
   const [aiPopupOpen, setAiPopupOpen] = useState(false);
   const [aiLoading, setAiLoading] = useState(false);

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -123,25 +123,24 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const { settings, updateSettings, t } = useSettings();
   const { speak, stop } = useAudio();
 
-  // Review mode: auto-play question + choices when question changes
+  // Auto-play question + choices when question changes or audio is toggled on
   useEffect(() => {
-    if (mode !== "review") return;
     const q = filteredQuestions[currentIndex];
     if (!q) return;
     speak(buildQuestionText(q));
     return () => { stop(); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentIndex, mode]);
+  }, [currentIndex, mode, settings.audioMode]);
 
-  // Review mode: auto-play answer reveal when card is flipped
+  // Auto-play answer reveal when card is flipped (review) or submitted (quiz)
   useEffect(() => {
-    if (mode !== "review" || !revealed) return;
+    if (!revealed && !submitted) return;
     const q = filteredQuestions[currentIndex];
     if (!q) return;
     stop();
     speak(buildAnswerRevealText(q, settings.language));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [revealed]);
+  }, [revealed, submitted, settings.audioMode]);
 
   const [langOpen, setLangOpen] = useState(false);
   const langRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary

- Remove `mode !== "review"` guard — TTS now works in quiz mode too
- Add `settings.audioMode` to effect deps — toggling ON immediately plays the current question without needing to navigate
- Same fix in AnswersClient

## Root cause

TTS effects only fired when `currentIndex` changed. If user toggled audio ON while staying on the same question, nothing happened. Also quiz mode was explicitly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)