### PR TITLE
fix: prevent overlapping TTS audio

### DIFF
--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -124,7 +124,9 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const { speak, stop } = useAudio();
 
   // Auto-play question + choices when question changes or audio is toggled on
+  // Skip if answer is already revealed/submitted to avoid overlap with reveal effect
   useEffect(() => {
+    if (revealed || submitted) return;
     const q = filteredQuestions[currentIndex];
     if (!q) return;
     speak(buildQuestionText(q));


### PR DESCRIPTION
## Summary

When `audioMode` is toggled on while a quiz answer is already submitted/revealed, both the question effect and the reveal effect fire simultaneously causing audio overlap. Fix by guarding the question effect with `if (revealed || submitted) return`.

## Trigger explanation

- Audio plays when: `currentIndex` changes (next question), `settings.audioMode` toggles ON, or `revealed`/`submitted` changes to true
- On page load: if audioMode was saved as ON, settings load from DB causes audioMode to change false→true, triggering playback of the current question

🤖 Generated with [Claude Code](https://claude.com/claude-code)