### PR TITLE
fix: make question source a clickable link in all views

### DIFF
--- a/components/AnswerRevealModal.tsx
+++ b/components/AnswerRevealModal.tsx
@@ -116,7 +116,12 @@ export default function AnswerRevealModal({ question, isCorrect, isLast, onNext,
           {(question.source || (question.explanationSources && question.explanationSources.length > 0)) && (
             <div className="space-y-1">
               {question.source && (
-                <p className="text-xs text-gray-400">Question source: {question.source}</p>
+                <p className="text-xs text-gray-400">
+                  Question source:{" "}
+                  <a href={question.source} target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-500 underline break-all">
+                    {question.source}
+                  </a>
+                </p>
               )}
               {question.explanationSources && question.explanationSources.length > 0 && (
                 <div>

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -766,9 +766,9 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
                               dangerouslySetInnerHTML={{ __html: q.question }}
                             />
                             {q.source && (
-                              <p className="text-[10px] text-gray-300 mt-2 truncate" title={q.source}>
+                              <a href={q.source} target="_blank" rel="noopener noreferrer" className="text-[10px] text-gray-300 hover:text-blue-400 mt-2 truncate block" title={q.source}>
                                 Source: {q.source}
-                              </p>
+                              </a>
                             )}
                           </div>
                           <div className="space-y-2">

--- a/components/QuizQuestion.tsx
+++ b/components/QuizQuestion.tsx
@@ -47,9 +47,9 @@ export default function QuizQuestion({
           dangerouslySetInnerHTML={{ __html: question.question }}
         />
         {question.source && (
-          <p className="text-[10px] text-gray-300 mt-2 truncate" title={question.source}>
+          <a href={question.source} target="_blank" rel="noopener noreferrer" className="text-[10px] text-gray-300 hover:text-blue-400 mt-2 truncate block" title={question.source}>
             Source: {question.source}
-          </p>
+          </a>
         )}
       </div>
 

--- a/components/ReviewReveal.tsx
+++ b/components/ReviewReveal.tsx
@@ -50,7 +50,12 @@ export default function ReviewReveal({ question, onNext, isLast, onAiExplain }: 
         {(question.source || question.explanationSources?.length > 0) && (
           <div className="mt-4 space-y-1">
             {question.source && (
-              <p className="text-xs text-gray-300">Question source: {question.source}</p>
+              <p className="text-xs text-gray-300">
+                Question source:{" "}
+                <a href={question.source} target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-500 underline break-all">
+                  {question.source}
+                </a>
+              </p>
             )}
             {question.explanationSources?.length > 0 && (
               <div>


### PR DESCRIPTION
## Summary
- `question.source` is now a clickable `<a>` link (opens in new tab) in all 4 views:
  - QuizQuestion (quiz mode question box)
  - QuizClient review mode (flashcard question box)
  - AnswerRevealModal (quiz mode answer card)
  - ReviewReveal (flashcard answer reveal)
- Previously `question.source` was plain text in all places; only `explanationSources` were links

🤖 Generated with [Claude Code](https://claude.com/claude-code)