### PR TITLE
fix: enable local dev -- remove edge runtime from local-only routes

### DIFF
--- a/app/api/local-exams/route.ts
+++ b/app/api/local-exams/route.ts
@@ -1,5 +1,3 @@
-export const runtime = "edge";
-
 import { NextResponse } from "next/server";
 
 // This route is for local development only.

--- a/app/api/local-questions/[examId]/route.ts
+++ b/app/api/local-questions/[examId]/route.ts
@@ -1,5 +1,3 @@
-export const runtime = "edge";
-
 import { NextResponse } from "next/server";
 
 // This route is for local development only.

--- a/components/AiExplainPopup.tsx
+++ b/components/AiExplainPopup.tsx
@@ -231,7 +231,7 @@ export default function AiExplainPopup({
               value={chatInput}
               onChange={(e) => setChatInput(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
+                if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
                   e.preventDefault();
                   handleChatSend();
                 }

--- a/components/ExamDetailClient.tsx
+++ b/components/ExamDetailClient.tsx
@@ -149,7 +149,7 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats }: 
               onChange={(e) => setExamName(e.target.value)}
               className="flex-1 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:border-transparent"
               placeholder="Exam name"
-              onKeyDown={(e) => { if (e.key === "Enter" && !e.isComposing) saveExamMeta(); if (e.key === "Escape") cancelEditMeta(); }}
+              onKeyDown={(e) => { if (e.key === "Enter" && !e.nativeEvent.isComposing) saveExamMeta(); if (e.key === "Escape") cancelEditMeta(); }}
             />
             <div className="flex items-center gap-0.5 bg-gray-100 rounded-lg p-0.5">
               {(["ja", "en"] as const).map((lang) => (


### PR DESCRIPTION
## Summary

- Remove \`export const runtime = "edge"\` from \`local-exams\` and \`local-questions\` routes so \`npm run dev\` works with CSV question data
- Fix TypeScript build errors: \`e.isComposing\` -> \`e.nativeEvent.isComposing\` in React \`onKeyDown\` handlers

## Why safe for Cloudflare

- Both routes guard with \`DEPLOY_TARGET !== "local"\` and return \`[]\` immediately in production
- \`wrangler.jsonc\` already has \`nodejs_compat\` flag

## Verified locally

- \`/api/local-questions/experience_cloud_consultant_exam_en\` returns 155 questions
- TTS API returns 200 + WAV audio that plays correctly
- \`npm run build\` passes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>