### PR TITLE
fix: remove source URL validation and domain guidance from AI explain

### DIFF
--- a/app/api/ai/explain/route.ts
+++ b/app/api/ai/explain/route.ts
@@ -8,35 +8,6 @@ import { DEFAULT_EXPLAIN_PROMPT } from "@/lib/types";
 import { getSetting } from "@/lib/db";
 import { getRequestContext } from "@cloudflare/next-on-pages";
 
-async function validateUrl(url: string): Promise<boolean> {
-  try {
-    const res = await fetch(url, {
-      method: "GET",
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; QuizBot/1.0)" },
-      signal: AbortSignal.timeout(5000),
-    });
-    if (!res.ok) return false;
-
-    const isSalesforce =
-      url.includes("help.salesforce.com") ||
-      url.includes("trailhead.salesforce.com") ||
-      url.includes("developer.salesforce.com");
-
-    if (isSalesforce) {
-      const text = await res.text();
-      if (
-        text.includes("We looked high and low") ||
-        text.includes("couldn't find that page") ||
-        text.includes("Page Not Found")
-      ) {
-        return false;
-      }
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 const AiResponseSchema = z.object({
   explanation: z.string(),
@@ -111,9 +82,5 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const rawSources = result.data.sources ?? [];
-  const validated = await Promise.all(rawSources.map(validateUrl));
-  const sources = rawSources.filter((_, i) => validated[i]);
-
-  return NextResponse.json({ ...result.data, sources });
+  return NextResponse.json(result.data);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -88,7 +88,7 @@ Respond ONLY with a JSON object (no markdown, no code fences) with exactly these
 - explanation: concise explanation of why the correct answer(s) are correct
 - answers: array of correct choice labels (e.g. ["A"] or ["A", "C"])
 - reasoning: brief reasoning for why you chose those answers
-- sources: array of 1–3 URLs that directly support the answer (official docs, Trailhead, etc.). Use [] if none found.`;
+- sources: array of 1–3 URLs that directly support the answer. Use [] if none found.`;
 
 export const DEFAULT_REFINE_PROMPT = `You are an expert editor for Salesforce/MuleSoft certification exam questions.
 Your task is to fix ONLY typos, grammatical errors, spelling mistakes, and awkward phrasing, missing line breaks (either in list, bullets) in the question text and answer choices.


### PR DESCRIPTION
## Summary
- Remove `validateUrl()` function that fetched Salesforce URLs to check for 404s — this added latency and could fail legitimately valid URLs
- Remove domain guidance ("official docs, Trailhead, etc.") from `DEFAULT_EXPLAIN_PROMPT` — the domain hint was causing Gemini to hallucinate plausible-looking but fake Salesforce URLs
- Sources are now passed through directly from Gemini's grounded search response; `googleSearch: {}` grounding already handles source relevance

## Test plan
- [ ] Open AI explain popup on any question, submit a query
- [ ] Verify popup does not close prematurely on IME Enter
- [ ] Check that sources shown are real grounded URLs from Google Search, not fabricated Salesforce links

🤖 Generated with [Claude Code](https://claude.com/claude-code)