### PR TITLE
fix(db): add D1Result type stub so run() meta.last_row_id compiles

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,11 +3,14 @@ import { DEFAULT_USER_SETTINGS } from "./types";
 import { getRequestContext } from "@cloudflare/next-on-pages";
 
 // Minimal D1 type stub – replaced by @cloudflare/workers-types after npm install
+export interface D1Result {
+  meta: { last_row_id: number; changes: number };
+}
 export interface D1PreparedStatement {
   bind(...values: unknown[]): D1PreparedStatement;
   all<T = unknown>(): Promise<{ results: T[] }>;
   first<T = unknown>(): Promise<T | null>;
-  run(): Promise<void>;
+  run(): Promise<D1Result>;
 }
 export interface D1Database {
   prepare(query: string): D1PreparedStatement;


### PR DESCRIPTION
## Summary

- The local `D1PreparedStatement` type stub defined `run(): Promise<void>`, causing a TypeScript compile error when accessing `result.meta.last_row_id` in `createSuggestion`.
- Fixed by adding a `D1Result` interface and changing `run()` to return `Promise<D1Result>`.

## Root cause

The previous PR (#55) introduced `result.meta.last_row_id` but the project's own type stub (not `@cloudflare/workers-types`) had `run(): Promise<void>`, making the build fail on Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)