### PR TITLE
feat: TTS default off, home lang selector, exam question table, settings prompt accordions

### DIFF
--- a/app/api/admin/questions/route.ts
+++ b/app/api/admin/questions/route.ts
@@ -1,9 +1,23 @@
 export const runtime = "edge";
 
 import { NextRequest, NextResponse } from "next/server";
-import { createQuestion } from "@/lib/db";
+import { createQuestion, getQuestions, getUserInvalidatedIds } from "@/lib/db";
 import { getUserEmail } from "@/lib/user";
 import type { Choice } from "@/lib/types";
+
+export async function GET(req: NextRequest) {
+  const examId = req.nextUrl.searchParams.get("examId");
+  if (!examId) return NextResponse.json({ error: "examId required" }, { status: 400 });
+
+  const userEmail = await getUserEmail();
+  const [questions, invalidatedIds] = await Promise.all([
+    getQuestions(examId),
+    userEmail ? getUserInvalidatedIds(userEmail, examId) : Promise.resolve([]),
+  ]);
+  const invalidatedSet = new Set(invalidatedIds);
+  const result = questions.map((q) => ({ ...q, invalidated: invalidatedSet.has(q.dbId) }));
+  return NextResponse.json({ questions: result });
+}
 
 export async function POST(req: NextRequest) {
   const body = await req.json() as {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import { Check, Sparkles, Wand2, BrainCircuit, RefreshCw, Target, Volume2, Zap } from "lucide-react";
+import { Check, Sparkles, Wand2, BrainCircuit, RefreshCw, Target, Volume2, Zap, BookOpen, ChevronDown } from "lucide-react";
 import { useSettings } from "@/lib/settings-context";
 import PageHeader from "@/components/PageHeader";
 
@@ -14,6 +14,8 @@ function SettingsInner() {
   const { settings, updateSettings, t } = useSettings();
   const [aiPrompt, setAiPrompt] = useState(settings.aiPrompt);
   const [aiRefinePrompt, setAiRefinePrompt] = useState(settings.aiRefinePrompt);
+  const [studyGuidePrompt, setStudyGuidePrompt] = useState(settings.studyGuidePrompt);
+  const [openPrompt, setOpenPrompt] = useState<string | null>(null);
   const [dailyGoal, setDailyGoal] = useState(settings.dailyGoal ?? 20);
   const [audioMode, setAudioMode] = useState(settings.audioMode ?? false);
   const [audioSpeed, setAudioSpeed] = useState(settings.audioSpeed ?? 1.0);
@@ -32,12 +34,13 @@ function SettingsInner() {
   useEffect(() => {
     setAiPrompt(settings.aiPrompt);
     setAiRefinePrompt(settings.aiRefinePrompt);
+    setStudyGuidePrompt(settings.studyGuidePrompt);
     setDailyGoal(settings.dailyGoal ?? 20);
     setAudioMode(settings.audioMode ?? false);
     setAudioSpeed(settings.audioSpeed ?? 1.0);
-    setAudioPrefetch(settings.audioPrefetch ?? 3);
+    setAudioPrefetch(settings.audioPrefetch ?? 0);
     setSkipRevealOnCorrect(settings.skipRevealOnCorrect ?? false);
-  }, [settings.aiPrompt, settings.aiRefinePrompt, settings.audioMode, settings.audioSpeed, settings.audioPrefetch, settings.skipRevealOnCorrect]);
+  }, [settings.aiPrompt, settings.aiRefinePrompt, settings.studyGuidePrompt, settings.audioMode, settings.audioSpeed, settings.audioPrefetch, settings.skipRevealOnCorrect]);
 
   // Load current gemini model and tts model from DB
   useEffect(() => {
@@ -67,7 +70,7 @@ function SettingsInner() {
   }
 
   async function handleSave() {
-    updateSettings({ aiPrompt, aiRefinePrompt, dailyGoal, audioMode, audioSpeed, audioPrefetch, skipRevealOnCorrect });
+    updateSettings({ aiPrompt, aiRefinePrompt, studyGuidePrompt, dailyGoal, audioMode, audioSpeed, audioPrefetch, skipRevealOnCorrect });
     const saves: Promise<unknown>[] = [];
     if (geminiModel) {
       saves.push(
@@ -97,36 +100,91 @@ function SettingsInner() {
       <PageHeader back={{ href: returnTo }} title={t("settings")} hideSettingsIcon />
       <main className="flex-1 px-4 sm:px-8 py-8 max-w-xl mx-auto w-full space-y-8">
 
-        {/* AI Explain Prompt */}
+        {/* Prompts (accordion) */}
         <section>
-          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1 flex items-center gap-1.5">
-            <Sparkles size={11} className="text-violet-400" />
-            {t("aiPrompt")}
-          </h2>
-          <p className="text-xs text-gray-400 mb-3">{t("aiPromptPlaceholder")}</p>
-          <textarea
-            value={aiPrompt}
-            onChange={(e) => setAiPrompt(e.target.value)}
-            rows={3}
-            className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-violet-400 focus:border-transparent resize-none"
-            placeholder={t("aiPromptPlaceholder")}
-          />
-        </section>
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">Prompts</h2>
+          <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden divide-y divide-gray-100">
+            {/* AI Explain Prompt */}
+            <div>
+              <button
+                type="button"
+                onClick={() => setOpenPrompt((v) => v === "explain" ? null : "explain")}
+                className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-50 transition-colors"
+              >
+                <span className="flex items-center gap-2 text-sm font-medium text-gray-700">
+                  <Sparkles size={13} className="text-violet-400" />
+                  {t("aiPrompt")}
+                </span>
+                <ChevronDown size={14} className={`text-gray-400 transition-transform ${openPrompt === "explain" ? "rotate-180" : ""}`} />
+              </button>
+              {openPrompt === "explain" && (
+                <div className="px-4 pb-4">
+                  <p className="text-xs text-gray-400 mb-2">{t("aiPromptPlaceholder")}</p>
+                  <textarea
+                    value={aiPrompt}
+                    onChange={(e) => setAiPrompt(e.target.value)}
+                    rows={6}
+                    className="w-full rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-xs text-gray-900 placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-violet-400 focus:border-transparent resize-y font-mono"
+                    placeholder={t("aiPromptPlaceholder")}
+                  />
+                </div>
+              )}
+            </div>
 
-        {/* AI Refine Prompt */}
-        <section>
-          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1 flex items-center gap-1.5">
-            <Wand2 size={11} className="text-amber-400" />
-            {t("aiRefinePrompt")}
-          </h2>
-          <p className="text-xs text-gray-400 mb-3">{t("aiRefinePromptPlaceholder")}</p>
-          <textarea
-            value={aiRefinePrompt}
-            onChange={(e) => setAiRefinePrompt(e.target.value)}
-            rows={3}
-            className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent resize-none"
-            placeholder={t("aiRefinePromptPlaceholder")}
-          />
+            {/* AI Refine Prompt */}
+            <div>
+              <button
+                type="button"
+                onClick={() => setOpenPrompt((v) => v === "refine" ? null : "refine")}
+                className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-50 transition-colors"
+              >
+                <span className="flex items-center gap-2 text-sm font-medium text-gray-700">
+                  <Wand2 size={13} className="text-amber-400" />
+                  {t("aiRefinePrompt")}
+                </span>
+                <ChevronDown size={14} className={`text-gray-400 transition-transform ${openPrompt === "refine" ? "rotate-180" : ""}`} />
+              </button>
+              {openPrompt === "refine" && (
+                <div className="px-4 pb-4">
+                  <p className="text-xs text-gray-400 mb-2">{t("aiRefinePromptPlaceholder")}</p>
+                  <textarea
+                    value={aiRefinePrompt}
+                    onChange={(e) => setAiRefinePrompt(e.target.value)}
+                    rows={6}
+                    className="w-full rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-xs text-gray-900 placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent resize-y font-mono"
+                    placeholder={t("aiRefinePromptPlaceholder")}
+                  />
+                </div>
+              )}
+            </div>
+
+            {/* Study Guide Prompt */}
+            <div>
+              <button
+                type="button"
+                onClick={() => setOpenPrompt((v) => v === "studyguide" ? null : "studyguide")}
+                className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-50 transition-colors"
+              >
+                <span className="flex items-center gap-2 text-sm font-medium text-gray-700">
+                  <BookOpen size={13} className="text-emerald-500" />
+                  Study Guide Prompt
+                </span>
+                <ChevronDown size={14} className={`text-gray-400 transition-transform ${openPrompt === "studyguide" ? "rotate-180" : ""}`} />
+              </button>
+              {openPrompt === "studyguide" && (
+                <div className="px-4 pb-4">
+                  <p className="text-xs text-gray-400 mb-2">System instruction for Study Guide generation. Use {"{examName}"} as a placeholder.</p>
+                  <textarea
+                    value={studyGuidePrompt}
+                    onChange={(e) => setStudyGuidePrompt(e.target.value)}
+                    rows={6}
+                    className="w-full rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-xs text-gray-900 placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent resize-y font-mono"
+                    placeholder="You are an expert on the &quot;{examName}&quot; certification exam..."
+                  />
+                </div>
+              )}
+            </div>
+          </div>
         </section>
 
         {/* AI Model */}

--- a/components/ExamDetailClient.tsx
+++ b/components/ExamDetailClient.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import type { CategoryStat, ExamMeta } from "@/lib/types";
 import PageHeader from "./PageHeader";
+import ExamQuestionTable from "./ExamQuestionTable";
 
 interface Props {
   exam: ExamMeta;
@@ -28,7 +29,7 @@ function pctTextColor(pct: number) {
   return "text-rose-500";
 }
 
-export default function ExamDetailClient({ exam, categoryStats: initialStats }: Props) {
+export default function ExamDetailClient({ exam, categoryStats: initialStats, userEmail }: Props) {
   const [stats, setStats] = useState<CategoryStat[]>(initialStats);
   const [statsLoading, setStatsLoading] = useState(true);
   const [selectedMode, setSelectedMode] = useState<"quiz" | "review">("quiz");
@@ -603,6 +604,7 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats }: 
 
           </div>
         </div>
+        <ExamQuestionTable examId={exam.id} userEmail={userEmail} />
       </main>
     </div>
   );

--- a/components/ExamListClient.tsx
+++ b/components/ExamListClient.tsx
@@ -249,37 +249,39 @@ export default function ExamListClient({ exams: initialExams }: Props) {
       <PageHeader
         title="Exams"
         right={
-          <>
-            {langOptions.length > 1 && (
-              <div className="flex items-center gap-0.5">
-                {langOptions.map((opt) => (
-                  <button
-                    key={opt.value}
-                    onClick={() => updateSettings({ language: opt.value })}
-                    className={`px-2 py-0.5 rounded-md text-xs font-medium transition-colors ${
-                      langFilter === opt.value
-                        ? "bg-gray-900 text-white"
-                        : "text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            )}
-            <Link
-              href="/profile"
-              className="p-1.5 rounded-lg text-gray-300 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-              title="Profile"
-            >
-              <User size={14} />
-            </Link>
-          </>
+          <Link
+            href="/profile"
+            className="p-1.5 rounded-lg text-gray-300 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            title="Profile"
+          >
+            <User size={14} />
+          </Link>
         }
       />
 
+      {/* Language selector */}
+      {langOptions.length > 1 && (
+        <div className="px-4 sm:px-8 pt-4 max-w-3xl mx-auto w-full">
+          <div className="flex gap-1 p-1 bg-gray-100 rounded-xl">
+            {langOptions.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => updateSettings({ language: opt.value })}
+                className={`flex-1 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                  langFilter === opt.value
+                    ? "bg-white text-gray-900 shadow-sm"
+                    : "text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Controls: search */}
-      <div className="px-4 sm:px-8 pt-5 pb-3 max-w-3xl mx-auto w-full">
+      <div className="px-4 sm:px-8 pt-3 pb-3 max-w-3xl mx-auto w-full">
         <div className="relative">
           <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none" />
           <input

--- a/components/ExamQuestionTable.tsx
+++ b/components/ExamQuestionTable.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { ChevronDown, ChevronUp, X, Search } from "lucide-react";
+import type { Question } from "@/lib/types";
+
+type QuestionWithInvalidated = Question & { invalidated: boolean };
+
+interface Props {
+  examId: string;
+  userEmail: string;
+}
+
+interface ModalQuestion extends QuestionWithInvalidated {}
+
+export default function ExamQuestionTable({ examId, userEmail }: Props) {
+  const [open, setOpen] = useState(false);
+  const [questions, setQuestions] = useState<QuestionWithInvalidated[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("__all__");
+  const [showInvalidatedOnly, setShowInvalidatedOnly] = useState(false);
+  const [modal, setModal] = useState<ModalQuestion | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  const loadQuestions = useCallback(async () => {
+    if (loaded) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/questions?examId=${encodeURIComponent(examId)}`);
+      const data = await res.json() as { questions: QuestionWithInvalidated[] };
+      setQuestions(data.questions ?? []);
+      setLoaded(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [examId, loaded]);
+
+  const handleToggle = useCallback(async () => {
+    const next = !open;
+    setOpen(next);
+    if (next) await loadQuestions();
+  }, [open, loadQuestions]);
+
+  const toggleInvalidated = useCallback(async (q: QuestionWithInvalidated, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!userEmail || togglingId === q.dbId) return;
+    setTogglingId(q.dbId);
+    try {
+      const res = await fetch(`/api/user/questions/${encodeURIComponent(q.dbId)}/invalidate`, { method: "POST" });
+      const { invalidated } = await res.json() as { invalidated: boolean };
+      setQuestions((prev) => prev.map((item) => item.dbId === q.dbId ? { ...item, invalidated } : item));
+      if (modal?.dbId === q.dbId) setModal((m) => m ? { ...m, invalidated } : m);
+    } finally {
+      setTogglingId(null);
+    }
+  }, [userEmail, togglingId, modal]);
+
+  const categories = useMemo(() => {
+    const cats = Array.from(new Set(questions.map((q) => q.category ?? ""))).filter(Boolean).sort();
+    return cats;
+  }, [questions]);
+
+  const filtered = useMemo(() => {
+    return questions.filter((q) => {
+      if (showInvalidatedOnly && !q.invalidated) return false;
+      if (categoryFilter !== "__all__" && (q.category ?? "") !== categoryFilter) return false;
+      if (search.trim()) {
+        const s = search.trim().toLowerCase();
+        return q.question.toLowerCase().includes(s);
+      }
+      return true;
+    });
+  }, [questions, search, categoryFilter, showInvalidatedOnly]);
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden mt-4">
+      {/* Accordion header */}
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between px-5 py-3.5 hover:bg-gray-50 transition-colors"
+      >
+        <span className="text-sm font-semibold text-gray-700">
+          Questions {loaded ? `(${questions.length})` : ""}
+        </span>
+        {open ? <ChevronUp size={15} className="text-gray-400" /> : <ChevronDown size={15} className="text-gray-400" />}
+      </button>
+
+      {open && (
+        <div className="border-t border-gray-100">
+          {/* Filter bar */}
+          <div className="px-4 py-3 flex items-center gap-2 border-b border-gray-100 flex-wrap">
+            <div className="relative flex-1 min-w-[140px]">
+              <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none" />
+              <input
+                type="text"
+                placeholder="Search questions..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full h-8 pl-7 pr-3 rounded-lg border border-gray-200 text-xs text-gray-700 placeholder:text-gray-300 focus:outline-none focus:ring-1 focus:ring-gray-300"
+              />
+            </div>
+            {categories.length > 0 && (
+              <select
+                value={categoryFilter}
+                onChange={(e) => setCategoryFilter(e.target.value)}
+                className="h-8 px-2 rounded-lg border border-gray-200 text-xs text-gray-700 bg-white focus:outline-none"
+              >
+                <option value="__all__">All categories</option>
+                {categories.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+            )}
+            <button
+              onClick={() => setShowInvalidatedOnly((v) => !v)}
+              className={`h-8 px-2.5 rounded-lg border text-xs font-medium transition-colors ${
+                showInvalidatedOnly
+                  ? "border-rose-300 bg-rose-50 text-rose-600"
+                  : "border-gray-200 text-gray-500 hover:bg-gray-50"
+              }`}
+            >
+              Invalidated
+            </button>
+          </div>
+
+          {loading ? (
+            <div className="px-5 py-6 text-center text-xs text-gray-400">Loading...</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-gray-100 bg-gray-50">
+                    <th className="text-left px-3 py-2 font-semibold text-gray-400 w-12 shrink-0">#</th>
+                    <th className="text-left px-3 py-2 font-semibold text-gray-400">Question</th>
+                    <th className="text-left px-3 py-2 font-semibold text-gray-400 w-28">Category</th>
+                    <th className="text-left px-3 py-2 font-semibold text-gray-400 w-16">Ans</th>
+                    <th className="text-center px-3 py-2 font-semibold text-gray-400 w-12">Dup</th>
+                    <th className="text-center px-3 py-2 font-semibold text-gray-400 w-16">Invalid</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-50">
+                  {filtered.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="px-5 py-6 text-center text-gray-300">No questions</td>
+                    </tr>
+                  ) : (
+                    filtered.map((q) => (
+                      <tr
+                        key={q.dbId}
+                        className="hover:bg-gray-50 cursor-pointer transition-colors"
+                        onDoubleClick={() => setModal(q)}
+                      >
+                        <td className="px-3 py-0 h-10 text-gray-400 tabular-nums w-12">{q.id}</td>
+                        <td className="px-3 py-0 h-10 max-w-0">
+                          <p className="truncate text-gray-700">{q.question.replace(/<[^>]+>/g, "")}</p>
+                        </td>
+                        <td className="px-3 py-0 h-10 w-28">
+                          <p className="truncate text-gray-500">{q.category ?? <span className="text-gray-300">—</span>}</p>
+                        </td>
+                        <td className="px-3 py-0 h-10 w-16">
+                          <span className="truncate text-gray-600 font-mono">{q.answers.join(", ")}</span>
+                        </td>
+                        <td className="px-3 py-0 h-10 w-12 text-center">
+                          {q.isDuplicate && (
+                            <span className="inline-block px-1.5 py-0.5 rounded text-gray-400 bg-gray-100 text-[10px]">dup</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-0 h-10 w-16 text-center">
+                          <input
+                            type="checkbox"
+                            checked={q.invalidated}
+                            disabled={togglingId === q.dbId || !userEmail}
+                            onChange={() => {}}
+                            onClick={(e) => toggleInvalidated(q, e)}
+                            className="w-3.5 h-3.5 rounded accent-rose-500 cursor-pointer disabled:opacity-40"
+                          />
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Double-click modal */}
+      {modal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/30 backdrop-blur-[2px]"
+          onClick={() => setModal(null)}
+        >
+          <div
+            className="bg-white rounded-2xl shadow-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between px-6 pt-5 pb-3 border-b border-gray-100">
+              <span className="text-sm font-semibold text-gray-700">Q{modal.id}</span>
+              <div className="flex items-center gap-3">
+                <label className="flex items-center gap-1.5 text-xs text-rose-500 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={modal.invalidated}
+                    disabled={togglingId === modal.dbId || !userEmail}
+                    onChange={() => {}}
+                    onClick={(e) => toggleInvalidated(modal, e)}
+                    className="w-3.5 h-3.5 rounded accent-rose-500 cursor-pointer disabled:opacity-40"
+                  />
+                  Invalidated
+                </label>
+                <button onClick={() => setModal(null)} className="text-gray-300 hover:text-gray-600 transition-colors">
+                  <X size={16} />
+                </button>
+              </div>
+            </div>
+            <div className="px-6 py-4 space-y-4">
+              <p className="text-sm text-gray-800 leading-relaxed whitespace-pre-wrap">{modal.question.replace(/<[^>]+>/g, "")}</p>
+              <div className="space-y-2">
+                {modal.choices.map((c) => {
+                  const isCorrect = modal.answers.includes(c.label);
+                  return (
+                    <div
+                      key={c.label}
+                      className={`flex items-start gap-3 px-4 py-2.5 rounded-xl border text-sm ${
+                        isCorrect
+                          ? "bg-emerald-50 border-emerald-200 text-emerald-900"
+                          : "border-gray-100 text-gray-600"
+                      }`}
+                    >
+                      <span className={`shrink-0 w-6 h-6 rounded-lg text-xs font-bold flex items-center justify-center ${
+                        isCorrect ? "bg-emerald-500 text-white" : "border border-gray-200 text-gray-400"
+                      }`}>
+                        {c.label}
+                      </span>
+                      <span className="leading-snug">{c.text}</span>
+                    </div>
+                  );
+                })}
+              </div>
+              {modal.explanation && (
+                <div className="text-xs text-gray-500 bg-gray-50 rounded-xl px-4 py-3 leading-relaxed whitespace-pre-wrap">
+                  {modal.explanation}
+                </div>
+              )}
+              {modal.category && (
+                <p className="text-xs text-gray-400">Category: {modal.category}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -697,6 +697,7 @@ export async function getAllUserSettings(userEmail: string): Promise<UserSetting
   const merged: UserSettings = { ...DEFAULT_USER_SETTINGS, ...raw };
   if (!merged.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
   if (!merged.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+  if (!merged.studyGuidePrompt) merged.studyGuidePrompt = DEFAULT_USER_SETTINGS.studyGuidePrompt;
   return merged;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,10 +66,11 @@ export interface UserSettings {
   language: "en" | "ja" | "zh" | "ko";
   aiPrompt: string;
   aiRefinePrompt: string;
+  studyGuidePrompt: string;
   dailyGoal: number; // questions per day target
   audioMode: boolean; // read questions aloud
   audioSpeed: number; // playback rate 0.5–4.0
-  audioPrefetch: number; // chunks to pre-fetch ahead while playing (0 = off, default: 3)
+  audioPrefetch: number; // chunks to pre-fetch ahead while playing (0 = off)
   skipRevealOnCorrect: boolean; // auto-advance without showing answer when correct
 }
 
@@ -132,13 +133,17 @@ export interface SessionRecord {
   correctCount: number | null;
 }
 
+export const DEFAULT_STUDY_GUIDE_PROMPT = `You are an expert on the "{examName}" certification exam.
+Analyze the exam questions below (grouped by category) and use Google Search to find the latest official exam guide information. Then produce a comprehensive Study Guide in Markdown format covering key topics, representative Q&As per category, and study priorities.`;
+
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   language: "en",
   aiPrompt: DEFAULT_EXPLAIN_PROMPT,
   aiRefinePrompt: DEFAULT_REFINE_PROMPT,
+  studyGuidePrompt: DEFAULT_STUDY_GUIDE_PROMPT,
   dailyGoal: 20,
   audioMode: false,
   audioSpeed: 1.0,
-  audioPrefetch: 5,
+  audioPrefetch: 0,
   skipRevealOnCorrect: false,
 };


### PR DESCRIPTION
## Summary
- TTS `audioPrefetch` default changed to `0` (fully off for new users)
- Home page language selector moved from header to content area with segmented control style
- Exam detail page: question table accordion below Start (search/filter, fixed rows, double-click modal, invalidate toggle)
- Settings page: all 3 prompts (Explain, Refine, Study Guide) wrapped in collapsible accordions; Study Guide prompt added as new user setting

## Test plan
- [ ] Home page shows language segmented control in content area (not header)
- [ ] Exam detail page: click "Questions" accordion → table loads with fixed-height rows, no wrapping
- [ ] Filter by text, category, or "Invalidated only" works
- [ ] Double-click row shows full question modal with correct answer highlights
- [ ] Invalidate checkbox toggles and persists
- [ ] Settings page: prompts collapsed by default, each opens independently
- [ ] New Study Guide Prompt accordion appears and saves
- [ ] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)