### PR TITLE
fix: wrong mode crash + flashcard width alignment

### DIFF
--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -256,6 +256,14 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const continueDisplayNum = continueIndex >= 0 ? continueIndex + 1 : null;
   const hasContinue = continueDisplayNum !== null;
 
+  // Clamp currentIndex when filteredQuestions shrinks (e.g., after stats reload)
+  useEffect(() => {
+    if (filteredQuestions.length > 0 && currentIndex >= filteredQuestions.length) {
+      setCurrentIndex(filteredQuestions.length - 1);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filteredQuestions.length]);
+
   // Auto-reset "wrong" filter when all wrong answers are cleared
   useEffect(() => {
     if (!statsLoaded) return;

--- a/components/ReviewReveal.tsx
+++ b/components/ReviewReveal.tsx
@@ -20,76 +20,80 @@ export default function ReviewReveal({ question, onNext, isLast, onAiExplain, qu
     <div className="flex-1 flex flex-col overflow-hidden min-h-0">
       {/* Scrollable content */}
       <div className="flex-1 overflow-y-auto px-4 sm:px-8 py-5">
-        <div className="flex items-center justify-between mb-3">
-          <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Answer</p>
-          {onAiExplain && (
-            <button onClick={onAiExplain} className="flex items-center gap-1.5 px-2.5 py-1 border border-gray-200 rounded-lg text-xs font-medium text-gray-500 hover:text-violet-500 hover:border-violet-200 transition-colors">
-              <Sparkles size={11} />
-              {t("explain")}
-            </button>
-          )}
-        </div>
-        <div className="flex flex-col gap-2 mb-6">
-          {question.choices
-            .filter((c) => question.answers.includes(c.label))
-            .map((c) => (
-              <div key={c.label} className="flex items-start gap-3 px-4 py-3 lg:px-5 lg:py-4 rounded-xl bg-emerald-50 border border-emerald-200">
-                <span className="shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-lg bg-emerald-500 text-white text-xs lg:text-sm font-bold flex items-center justify-center mt-0.5">
-                  {c.label}
-                </span>
-                <span className="text-sm lg:text-base text-emerald-900 leading-snug">{c.text}</span>
-              </div>
-            ))
-          }
-        </div>
-
-        {question.explanation && (
-          <>
-            <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">Explanation</p>
-            <p className="text-sm leading-relaxed text-gray-700 whitespace-pre-wrap">{question.explanation}</p>
-          </>
-        )}
-        {/* Sources */}
-        {question.explanationSources?.length > 0 && (
-          <div className="mt-4">
-            <p className="text-xs text-gray-400 font-medium mb-1">References:</p>
-            <ul className="space-y-0.5">
-              {question.explanationSources.map((url, i) => (
-                <li key={i}>
-                  <a
-                    href={url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs text-blue-400 hover:text-blue-500 underline break-all"
-                  >
-                    {url}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {/* Timestamps */}
-        {(question.addedAt || question.createdAt) && (
-          <p className="text-xs text-gray-400 mt-2">
-            {question.addedAt && <>Added: {new Date(question.addedAt).toLocaleDateString()}</>}
-            {question.createdAt && question.createdAt !== question.addedAt && (
-              <> &middot; Created: {new Date(question.createdAt).toLocaleDateString()}</>
+        <div className="max-w-3xl mx-auto w-full">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Answer</p>
+            {onAiExplain && (
+              <button onClick={onAiExplain} className="flex items-center gap-1.5 px-2.5 py-1 border border-gray-200 rounded-lg text-xs font-medium text-gray-500 hover:text-violet-500 hover:border-violet-200 transition-colors">
+                <Sparkles size={11} />
+                {t("explain")}
+              </button>
             )}
-          </p>
-        )}
+          </div>
+          <div className="flex flex-col gap-2 mb-6">
+            {question.choices
+              .filter((c) => question.answers.includes(c.label))
+              .map((c) => (
+                <div key={c.label} className="flex items-start gap-3 px-4 py-3 lg:px-5 lg:py-4 rounded-xl bg-emerald-50 border border-emerald-200">
+                  <span className="shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-lg bg-emerald-500 text-white text-xs lg:text-sm font-bold flex items-center justify-center mt-0.5">
+                    {c.label}
+                  </span>
+                  <span className="text-sm lg:text-base text-emerald-900 leading-snug">{c.text}</span>
+                </div>
+              ))
+            }
+          </div>
 
-        <SuggestPanel questionId={questionDbId} choices={choices} />
+          {question.explanation && (
+            <>
+              <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">Explanation</p>
+              <p className="text-sm leading-relaxed text-gray-700 whitespace-pre-wrap">{question.explanation}</p>
+            </>
+          )}
+          {/* Sources */}
+          {question.explanationSources?.length > 0 && (
+            <div className="mt-4">
+              <p className="text-xs text-gray-400 font-medium mb-1">References:</p>
+              <ul className="space-y-0.5">
+                {question.explanationSources.map((url, i) => (
+                  <li key={i}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-400 hover:text-blue-500 underline break-all"
+                    >
+                      {url}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {/* Timestamps */}
+          {(question.addedAt || question.createdAt) && (
+            <p className="text-xs text-gray-400 mt-2">
+              {question.addedAt && <>Added: {new Date(question.addedAt).toLocaleDateString()}</>}
+              {question.createdAt && question.createdAt !== question.addedAt && (
+                <> &middot; Created: {new Date(question.createdAt).toLocaleDateString()}</>
+              )}
+            </p>
+          )}
+
+          <SuggestPanel questionId={questionDbId} choices={choices} />
+        </div>
       </div>
 
       {/* Next */}
       <div className="shrink-0 px-4 sm:px-8 py-4 border-t border-gray-100">
-        <button
-          onClick={onNext}
-          className="w-full h-10 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors flex items-center justify-center gap-1.5"
-        >
-          {isLast ? <CheckCircle2 size={16} /> : <><ChevronRight size={15} /> <span className="text-xs opacity-40 hidden sm:inline">→ Enter</span></>}
-        </button>
+        <div className="max-w-3xl mx-auto w-full">
+          <button
+            onClick={onNext}
+            className="w-full h-10 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors flex items-center justify-center gap-1.5"
+          >
+            {isLast ? <CheckCircle2 size={16} /> : <><ChevronRight size={15} /> <span className="text-xs opacity-40 hidden sm:inline">→ Enter</span></>}
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Fix crash in wrong-only mode: `currentIndex` could go out of bounds when DB stats reload and shrink `filteredQuestions`. Added a clamp effect to prevent `filteredQuestions[currentIndex]` from being `undefined`.
- Fix flashcard (review mode) width inconsistency: `ReviewReveal` (answer side) was missing the `max-w-3xl mx-auto w-full` wrapper that the question side uses, causing the card to visually widen on flip.

## Test plan

- [ ] Open an exam in wrong-only mode → should show wrong questions without crash
- [ ] Open exam in flashcard (review) mode → flip card → answer side width matches question side width
- [ ] Stats reload mid-session (e.g., open DevTools and trigger API response) → no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)