### PR TITLE
fix(grounding): restrict Google Search to official Salesforce/MuleSoft domains

### DIFF
--- a/app/api/ai/study-guide/route.ts
+++ b/app/api/ai/study-guide/route.ts
@@ -141,7 +141,7 @@ ${userStats ? `## Your Learning Trends & Wrong Answer Patterns
 ${categoryLines.join("\n")}
 ${userStatsSection}
 
-Important: Use Google Search to look up "${examName} exam guide" and "${examName} certification" for the latest official information.
+Important: Use Google Search to look up "${examName} exam guide" and "${examName} certification" for the latest official information. Limit searches to official Salesforce and MuleSoft sources only (help.salesforce.com, developer.salesforce.com, trailhead.salesforce.com, docs.mulesoft.com).
 ${langInstruction[lang] ?? langInstruction["en"]}`;
 
   const ai = new GoogleGenAI({ apiKey });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -89,7 +89,7 @@ Choices:
 Currently recorded answer(s): {answers}
 {explanation}
 
-Please verify the correct answer(s) using your knowledge and web search if needed.
+When searching, limit searches to official Salesforce and MuleSoft sources only (help.salesforce.com, developer.salesforce.com, trailhead.salesforce.com, docs.mulesoft.com). Do not reference unrelated domains.
 Respond ONLY with a JSON object (no markdown, no code fences) with exactly these keys:
 { "explanation": "...", "answers": ["A"], "reasoning": "..." }
 - explanation: concise explanation of why the correct answer(s) are correct
@@ -100,6 +100,7 @@ export const DEFAULT_REFINE_PROMPT = `You are an expert editor for Salesforce/Mu
 Your task is to fix ONLY typos, grammatical errors, spelling mistakes, and awkward phrasing, missing line breaks (either in list, bullets; 1.xxx, 1).xxx, *xxx , - xxx, etc.) in the question text and answer choices.
 Do NOT change the meaning, technical content, correct answers, or add/remove choices.
 Do NOT rewrite or rephrase if there is no error — preserve the original wording as much as possible.
+When searching, limit searches to official Salesforce and MuleSoft sources only (help.salesforce.com, developer.salesforce.com, trailhead.salesforce.com, docs.mulesoft.com). Do not reference unrelated domains.
 
 Question:
 {question}


### PR DESCRIPTION
## Summary
- explain/refine/study-guide の各プロンプトに検索ドメイン制限の指示を追加
- `help.salesforce.com`, `developer.salesforce.com`, `trailhead.salesforce.com`, `docs.mulesoft.com` のみを参照するよう指定

## Test plan
- [ ] AI解説を実行し、sourcesに公式Salesforce URLのみ返ることを確認
- [ ] 無関係なドメイン(例: blog, Quora等)が混入しないことを確認