### PR TITLE
feat(ux): consistent buttons, wrong-answer shake, improved empty state, icon bounce

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -204,3 +204,38 @@ body {
 .toast-slide-in-left {
   animation: toast-slide-in-left 0.22s ease-out both;
 }
+
+/* ── Wrong answer shake ── */
+@keyframes shake-x {
+  0%, 100% { transform: translateX(0); }
+  15%  { transform: translateX(-7px); }
+  30%  { transform: translateX(6px); }
+  45%  { transform: translateX(-5px); }
+  60%  { transform: translateX(4px); }
+  75%  { transform: translateX(-2px); }
+  90%  { transform: translateX(1px); }
+}
+.shake-x {
+  animation: shake-x 0.42s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
+/* ── Result icon bounce (modal) ── */
+@keyframes icon-bounce {
+  0%   { transform: scale(0);    opacity: 0; }
+  55%  { transform: scale(1.22); opacity: 1; }
+  75%  { transform: scale(0.92); }
+  90%  { transform: scale(1.05); }
+  100% { transform: scale(1);    opacity: 1; }
+}
+.icon-bounce {
+  animation: icon-bounce 0.48s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* ── Empty state float ── */
+@keyframes float-y {
+  0%, 100% { transform: translateY(0px); }
+  50%      { transform: translateY(-10px); }
+}
+.float-y {
+  animation: float-y 3s ease-in-out infinite;
+}

--- a/components/AiExplainPopup.tsx
+++ b/components/AiExplainPopup.tsx
@@ -257,7 +257,7 @@ export default function AiExplainPopup({
           <div className="px-4 pb-4 pt-1 flex gap-2 shrink-0">
             <button
               onClick={onDismiss}
-              className="flex-1 py-2 rounded-xl border border-gray-200 text-gray-500 text-sm hover:bg-gray-50 transition-colors flex items-center justify-center gap-1.5"
+              className="flex-1 h-10 rounded-xl border border-gray-200 text-gray-500 text-sm hover:bg-gray-50 transition-colors flex items-center justify-center gap-1.5"
             >
               {t("dismiss")}
               <kbd className="text-[10px] bg-gray-100 text-gray-400 px-1.5 py-0.5 rounded-md font-mono hidden sm:inline">⌫</kbd>
@@ -265,7 +265,7 @@ export default function AiExplainPopup({
             <button
               onClick={onSuggest}
               disabled={suggesting}
-              className="flex-1 py-2 rounded-xl border border-violet-200 text-violet-600 bg-violet-50 text-sm font-semibold hover:bg-violet-100 disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5"
+              className="flex-1 h-10 rounded-xl border border-violet-200 text-violet-600 bg-violet-50 text-sm font-semibold hover:bg-violet-100 disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5"
             >
               {suggesting ? (
                 <Loader2 size={13} className="animate-spin" />
@@ -277,7 +277,7 @@ export default function AiExplainPopup({
             <button
               onClick={onAdopt}
               disabled={adopting}
-              className="flex-1 py-2 rounded-xl bg-violet-600 text-white text-sm font-semibold hover:bg-violet-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5"
+              className="flex-1 h-10 rounded-xl bg-violet-600 text-white text-sm font-semibold hover:bg-violet-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5"
             >
               {adopting ? (
                 <Loader2 size={13} className="animate-spin" />

--- a/components/AnswerRevealModal.tsx
+++ b/components/AnswerRevealModal.tsx
@@ -70,7 +70,7 @@ export default function AnswerRevealModal({ question, isCorrect, isLast, onNext,
       `}>
         {/* Header */}
         <div className={`shrink-0 flex items-center gap-3 px-6 pt-5 pb-4 border-b ${isCorrect ? "border-gray-100" : "border-rose-100"}`}>
-          <div className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${isCorrect ? "bg-emerald-100" : "bg-rose-100"}`}>
+          <div className={`icon-bounce w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${isCorrect ? "bg-emerald-100" : "bg-rose-100"}`}>
             {isCorrect
               ? <CheckCircle2 size={22} className="text-emerald-500" strokeWidth={2.5} />
               : <XCircle size={22} className="text-rose-500" strokeWidth={2.5} />

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -114,6 +114,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const [refineError, setRefineError] = useState<string | null>(null);
   const [refineAdopting, setRefineAdopting] = useState(false);
 
+  const [shakeKey, setShakeKey] = useState(0);
   const [sessionId] = useState<string>(() => crypto.randomUUID());
   const [sessionCorrectCount, setSessionCorrectCount] = useState(0);
   const [filterResetToast, setFilterResetToast] = useState(false);
@@ -324,6 +325,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     }
     const correct = q.answers.length === selected.size && q.answers.every((a) => selected.has(a));
     setIsCorrect(correct);
+    if (!correct) setShakeKey((k) => k + 1);
     if (filter === "wrong" && correct) {
       submittedWrongQIdRef.current = q.id;
       pendingWrongAdvanceRef.current = true;
@@ -659,19 +661,31 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const showAnswerModal = mode === "quiz" && submitted;
 
   if (filteredQuestions.length === 0) {
+    const isAllCleared = filter === "wrong";
     return (
-      <div className="h-screen flex flex-col items-center justify-center gap-4 px-4">
-        <AlertCircle size={32} className="text-gray-300" />
-        <p className="font-semibold text-gray-700">
-          {filter === "wrong" ? t("noWrongAnswers") : t("noQuestions")}
-        </p>
+      <div className="h-screen flex flex-col items-center justify-center gap-5 px-4 text-center">
+        <div className={`float-y ${isAllCleared ? "text-emerald-400" : "text-gray-300"}`}>
+          {isAllCleared
+            ? <CheckCircle2 size={52} strokeWidth={1.25} />
+            : <AlertCircle size={52} strokeWidth={1.25} />
+          }
+        </div>
+        <div>
+          <p className="font-semibold text-gray-800 text-lg">
+            {isAllCleared ? "All cleared!" : t("noQuestions")}
+          </p>
+          {isAllCleared && (
+            <p className="text-sm text-gray-400 mt-1">You&apos;ve mastered all the wrong answers.</p>
+          )}
+        </div>
         {(filter === "wrong" || excludeDuplicates) && (
-          <button onClick={() => { setFilter("all"); setExcludeDuplicates(false); }} className="px-4 py-2 rounded-xl bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 transition-colors">
+          <button onClick={() => { setFilter("all"); setExcludeDuplicates(false); }} className="h-10 px-5 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors">
             {t("showAll")}
           </button>
         )}
-        <button onClick={() => { doCompleteSession(); router.push(backHref); }} className="text-sm text-gray-400 hover:text-gray-700 flex items-center gap-1.5">
+        <button onClick={() => { doCompleteSession(); router.push(backHref); }} className="text-sm text-gray-400 hover:text-gray-700 flex items-center gap-1.5 transition-colors">
           <ArrowLeft size={14} />
+          Back
         </button>
       </div>
     );
@@ -795,8 +809,8 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
       {/* ── Main ── */}
       <div className="flex-1 flex flex-col lg:flex-row overflow-hidden" onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
 
-        {/* Left panel */}
-        <div className={`
+        {/* Left panel — key=shakeKey forces animation restart on each wrong answer */}
+        <div key={`panel-${shakeKey}`} className={`
           min-h-0 flex-1 flex flex-col overflow-hidden
           border-b lg:border-b-0 lg:border-r border-gray-200
           transition-colors duration-300
@@ -805,6 +819,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
             : isCorrect === true  ? "bg-emerald-50"
             : isCorrect === false ? "bg-rose-50"
             : "bg-white"}
+          ${submitted && isCorrect === false ? "shake-x" : ""}
         `}>
           {/* Position indicator */}
           <div className="shrink-0 px-4 sm:px-8 pt-4 sm:pt-5 pb-3 flex items-center justify-between">

--- a/components/QuizQuestion.tsx
+++ b/components/QuizQuestion.tsx
@@ -92,11 +92,11 @@ export default function QuizQuestion({
               key={choice.label}
               onClick={() => onToggle(choice.label)}
               disabled={submitted}
-              className={`w-full text-left border rounded-xl px-4 py-3 lg:px-5 lg:py-4 transition-all duration-100 active:scale-[0.97] ${ring} ${submitted ? "cursor-default option-reveal" : "cursor-pointer"}`}
+              className={`w-full text-left border rounded-xl px-4 py-3 lg:px-5 lg:py-4 transition-all duration-150 active:scale-[0.97] ${ring} ${submitted ? "cursor-default option-reveal" : "cursor-pointer hover:shadow-sm"}`}
               style={submitted ? { animationDelay: `${i * 50}ms`, animationFillMode: "both" } : undefined}
             >
               <div className="flex items-start gap-3">
-                <span className={`shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-lg border text-xs lg:text-sm font-bold flex items-center justify-center transition-all ${badge}`}>
+                <span className={`shrink-0 w-6 h-6 lg:w-7 lg:h-7 rounded-lg border text-xs lg:text-sm font-bold flex items-center justify-center transition-all duration-150 ${badge}`}>
                   {choice.label}
                 </span>
                 <span className={`text-sm lg:text-base leading-relaxed pt-0.5 whitespace-pre-wrap ${textColor}`}>


### PR DESCRIPTION
## Summary

- **A1 — Button height consistency**: Normalize `AiExplainPopup` action buttons (Dismiss/Suggest/Adopt) from `py-2` to `h-10`, matching the design system
- **B2 — Wrong-answer shake**: Left panel shakes horizontally on incorrect answer (`shake-x` animation). `shakeKey` state forces animation restart on consecutive wrong answers
- **B2 — Result icon bounce**: `AnswerRevealModal` correct/incorrect icon pops in with spring bounce (`icon-bounce`)
- **B4 — Improved empty state**: When Wrong Only filter is exhausted, shows "All cleared!" with subtext and a floating icon (`float-y`), instead of a plain error icon

## New CSS animations (`globals.css`)

| Class | Effect |
|---|---|
| `shake-x` | Horizontal shake, 0.42s, cubic-bezier — wrong answer feedback |
| `icon-bounce` | Scale-in spring bounce, 0.48s — modal result icon |
| `float-y` | Gentle vertical float loop, 3s — empty state illustration |

## Test plan

- [ ] Answer a question incorrectly → left panel shakes
- [ ] Answer wrong twice in a row → shake plays each time
- [ ] Submit answer → modal opens, result icon bounces in
- [ ] Set filter to Wrong Only, answer all wrong questions correctly → "All cleared!" empty state with floating icon
- [ ] Open AI Explain popup → Dismiss/Suggest/Adopt buttons are same height (40px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)