### PR TITLE
fix: add Clerk env vars to CI build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
         run: npm run build:cf
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
 
       - name: Deploy to Cloudflare Pages
         run: npx wrangler pages deploy .vercel/output/static --project-name quiz --branch main


### PR DESCRIPTION
## Summary
Add `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` to the build step env in CI workflow.
Without these, `ClerkProvider` in the layout causes a prerender failure at build time.

## Required action
After merging, add these two secrets to the GitHub **production** environment:
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` — from Clerk Dashboard → API Keys
- `CLERK_SECRET_KEY` — from Clerk Dashboard → API Keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)