### PR TITLE
fix: add /login to public routes to prevent auth redirect loop

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-const isPublicRoute = createRouteMatcher(["/unauthorized"]);
+const isPublicRoute = createRouteMatcher(["/login", "/unauthorized"]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) await auth.protect();


### PR DESCRIPTION
## Summary
Add `/login` to `isPublicRoute` matcher. Without this, unauthenticated users hitting the login page get caught in an infinite redirect loop (login → auth.protect() → login → ...).

🤖 Generated with [Claude Code](https://claude.com/claude-code)