### PR TITLE
fix: set Clerk signInUrl to /login to resolve 500 errors

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClerkProvider>
+    <ClerkProvider signInUrl="/login" signInFallbackRedirectUrl="/" afterSignOutUrl="/login">
       <html lang="en">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -70,7 +70,11 @@ async function csvQuestions(examId: string): Promise<Question[]> {
 
 export async function getExamList(): Promise<ExamMeta[]> {
   const d1 = getDB();
-  if (!d1) return csvExamList();
+  if (!d1) {
+    // csvExamList uses Node.js fs which is unavailable in edge runtime (Cloudflare Workers)
+    if (process.env.NEXT_RUNTIME === "edge") return [];
+    return csvExamList();
+  }
 
   // Complex GROUP BY + aggregation — keep as raw SQL via db.$client
   const result = await d1

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-const isPublicRoute = createRouteMatcher(["/login", "/unauthorized"]);
+const isPublicRoute = createRouteMatcher(["/login", "/sign-in", "/unauthorized"]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) await auth.protect();


### PR DESCRIPTION
## Root cause
`auth.protect()` redirects unauthenticated users to `/sign-in` (Clerk default), but this app's login page is at `/login`. Since `/sign-in` doesn't exist and is also protected, it caused an infinite redirect loop → 500.

## Changes
- `ClerkProvider`: add `signInUrl="/login"` and `afterSignOutUrl="/login"`
- `middleware.ts`: add `/sign-in` to public routes as safety net
- `lib/db.ts`: guard `csvExamList()` call in edge runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)