### PR TITLE
fix: restore @salesforce.com domain restriction

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,22 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+const ALLOWED_DOMAINS = ["salesforce.com"];
 
 const isPublicRoute = createRouteMatcher(["/login", "/sign-in", "/unauthorized"]);
 
 export default clerkMiddleware(async (auth, req) => {
-  if (!isPublicRoute(req)) await auth.protect();
+  if (isPublicRoute(req)) return;
+
+  const { userId, sessionClaims } = await auth.protect();
+
+  if (userId) {
+    const email = (sessionClaims?.email ?? "") as string;
+    const allowed = ALLOWED_DOMAINS.some((d) => email.endsWith(`@${d}`));
+    if (!allowed) {
+      return NextResponse.redirect(new URL("/unauthorized", req.url));
+    }
+  }
 });
 
 export const config = {


### PR DESCRIPTION
## Summary
Restore domain restriction that existed in the old custom auth (`lib/auth.ts`).
- Only `@salesforce.com` email addresses can access protected routes
- Non-matching domains are redirected to `/unauthorized`
- Public routes (`/login`, `/sign-in`, `/unauthorized`) remain accessible to all

## Also needed in Clerk Dashboard
Configure → Restrictions → Allowlist → add `salesforce.com` to block sign-ups from other domains at the Clerk level too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)