### PR TITLE
feat: persist TTS audio to IndexedDB

### DIFF
--- a/hooks/useAudio.ts
+++ b/hooks/useAudio.ts
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useCallback } from "react";
 import { useSettings } from "@/lib/settings-context";
+import { makeCacheKey, getAudioBlob, setAudioBlob } from "@/lib/audioDb";
 
 // Session-scoped cache: text → Object URL (WAV blob)
 const audioCache = new Map<string, string>();
@@ -34,6 +35,17 @@ export function useAudio() {
     if (existing) return existing;
     const promise = (async () => {
       try {
+        // Check IndexedDB persistent cache
+        const cacheKey = await makeCacheKey(text).catch(() => null);
+        if (cacheKey) {
+          const stored = await getAudioBlob(cacheKey).catch(() => null);
+          if (stored) {
+            const objectUrl = URL.createObjectURL(stored);
+            audioCache.set(text, objectUrl);
+            return objectUrl;
+          }
+        }
+
         const res = await fetch("/api/audio/tts", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -43,6 +55,9 @@ export function useAudio() {
         const blob = await res.blob();
         const objectUrl = URL.createObjectURL(blob);
         audioCache.set(text, objectUrl);
+        if (cacheKey) {
+          setAudioBlob(cacheKey, blob).catch(() => {});
+        }
         return objectUrl;
       } catch {
         return null;

--- a/lib/audioDb.ts
+++ b/lib/audioDb.ts
@@ -1,0 +1,69 @@
+const DB_NAME = "tts-audio";
+const STORE = "blobs";
+const MAX_ENTRIES = 200;
+const CACHE_KEY_PREFIX = "gemini-2.5-flash-preview-tts:Aoede";
+
+async function sha256hex(text: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function makeCacheKey(text: string): Promise<string> {
+  return `${CACHE_KEY_PREFIX}:${await sha256hex(text)}`;
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { keyPath: "key" });
+        store.createIndex("savedAt", "savedAt");
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function getAudioBlob(key: string): Promise<Blob | null> {
+  const db = await openDB();
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE, "readonly");
+    const req = tx.objectStore(STORE).get(key);
+    req.onsuccess = () => resolve(req.result?.blob ?? null);
+    req.onerror = () => resolve(null);
+  });
+}
+
+export async function setAudioBlob(key: string, blob: Blob): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, "readwrite");
+    const store = tx.objectStore(STORE);
+
+    // Check count and evict oldest if at limit
+    const countReq = store.count();
+    countReq.onsuccess = () => {
+      if (countReq.result >= MAX_ENTRIES) {
+        const index = store.index("savedAt");
+        const cursorReq = index.openCursor();
+        cursorReq.onsuccess = () => {
+          const cursor = cursorReq.result;
+          if (cursor) {
+            cursor.delete();
+          }
+          store.put({ key, blob, savedAt: Date.now() });
+        };
+      } else {
+        store.put({ key, blob, savedAt: Date.now() });
+      }
+    };
+
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}


### PR DESCRIPTION
## Summary
- Add `lib/audioDb.ts`: IndexedDB wrapper storing WAV blobs keyed by `SHA-256(text)` with model/voice prefix
- Update `hooks/useAudio.ts`: check IndexedDB before calling `/api/audio/tts`; save new blobs to IndexedDB after fetch
- Evicts oldest entry when store exceeds 200 entries; all IDB calls fail silently (private browsing safe)

## Test plan
- [ ] Play a question — audio generates and Network shows `/api/audio/tts` call
- [ ] DevTools → Application → IndexedDB → `tts-audio` → `blobs`: entry visible with key `gemini-2.5-flash-preview-tts:Aoede:...`
- [ ] Reload page → replay same question → no `/api/audio/tts` request in Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)