### PR TITLE
feat: suggest panel - count badge, date fix, adopt/delete buttons

### DIFF
--- a/app/api/suggestions/[id]/adopt/route.ts
+++ b/app/api/suggestions/[id]/adopt/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSuggestionById, getQuestionById, updateQuestion } from "@/lib/db";
+import { getUserEmail } from "@/lib/user";
+
+export const runtime = "edge";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const suggestion = await getSuggestionById(Number(id));
+  if (!suggestion) {
+    return NextResponse.json({ error: "suggestion not found" }, { status: 404 });
+  }
+
+  const question = await getQuestionById(suggestion.questionId);
+  if (!question) {
+    return NextResponse.json({ error: "question not found" }, { status: 404 });
+  }
+
+  const userEmail = await getUserEmail();
+  await updateQuestion(
+    suggestion.questionId,
+    {
+      question_text: question.question,
+      options: question.choices,
+      answers: suggestion.suggestedAnswers ?? question.answers,
+      explanation: suggestion.suggestedExplanation ?? question.explanation,
+      source: question.source,
+      explanation_sources: question.explanationSources,
+      change_reason: `Adopted from suggestion #${id}`,
+    },
+    userEmail
+  );
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/suggestions/[id]/route.ts
+++ b/app/api/suggestions/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { deleteSuggestion } from "@/lib/db";
+
+export const runtime = "edge";
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  await deleteSuggestion(Number(id));
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/suggestions/route.ts
+++ b/app/api/suggestions/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSuggestions, createSuggestion } from "@/lib/db";
+import { getSuggestions, getSuggestionCount, createSuggestion } from "@/lib/db";
 import { getUserEmail } from "@/lib/user";
 
 export const runtime = "edge";
@@ -7,6 +7,12 @@ export const runtime = "edge";
 export async function GET(req: NextRequest) {
   const questionId = req.nextUrl.searchParams.get("questionId");
   if (!questionId) return NextResponse.json({ error: "questionId required" }, { status: 400 });
+
+  if (req.nextUrl.searchParams.get("count") === "1") {
+    const count = await getSuggestionCount(questionId);
+    return NextResponse.json({ count });
+  }
+
   const suggestions = await getSuggestions(questionId);
   return NextResponse.json(suggestions);
 }

--- a/components/SuggestPanel.tsx
+++ b/components/SuggestPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { ChevronDown, ChevronUp, Plus, Loader2, Bot, User } from "lucide-react";
+import { useState, useCallback, useEffect } from "react";
+import { ChevronDown, ChevronUp, Plus, Loader2, Bot, User, Trash2, Check } from "lucide-react";
 import type { Choice, Suggestion } from "@/lib/types";
 import { useSettings } from "@/lib/settings-context";
 
@@ -14,6 +14,7 @@ export default function SuggestPanel({ questionId, choices }: Props) {
   const { t } = useSettings();
   const [expanded, setExpanded] = useState(false);
   const [suggestions, setSuggestions] = useState<Suggestion[] | null>(null);
+  const [count, setCount] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [formAnswers, setFormAnswers] = useState<string[]>([]);
@@ -22,6 +23,13 @@ export default function SuggestPanel({ questionId, choices }: Props) {
   const [submitting, setSubmitting] = useState(false);
   const [successMsg, setSuccessMsg] = useState("");
 
+  useEffect(() => {
+    fetch(`/api/suggestions?questionId=${encodeURIComponent(questionId)}&count=1`)
+      .then((r) => r.json())
+      .then((data: { count: number }) => setCount(data.count))
+      .catch(() => {/* ignore */});
+  }, [questionId]);
+
   const load = useCallback(async () => {
     if (suggestions !== null) return;
     setLoading(true);
@@ -29,6 +37,7 @@ export default function SuggestPanel({ questionId, choices }: Props) {
       const res = await fetch(`/api/suggestions?questionId=${encodeURIComponent(questionId)}`);
       const data = await res.json() as Suggestion[];
       setSuggestions(data);
+      setCount(data.length);
     } catch {
       setSuggestions([]);
     } finally {
@@ -65,6 +74,7 @@ export default function SuggestPanel({ questionId, choices }: Props) {
       const data = await res.json() as { ok: boolean; suggestion: Suggestion };
       if (data.ok) {
         setSuggestions((prev) => [data.suggestion, ...(prev ?? [])]);
+        setCount((c) => (c !== null ? c + 1 : 1));
         setShowForm(false);
         setFormAnswers([]);
         setFormExplanation("");
@@ -77,7 +87,17 @@ export default function SuggestPanel({ questionId, choices }: Props) {
     }
   };
 
-  const count = suggestions?.length ?? 0;
+  const handleDelete = (id: number) => {
+    setSuggestions((prev) => prev?.filter((s) => s.id !== id) ?? null);
+    setCount((c) => (c !== null ? c - 1 : null));
+  };
+
+  const handleAdopt = (id: number) => {
+    setSuccessMsg(t("suggestSuccess"));
+    setTimeout(() => setSuccessMsg(""), 3000);
+    setSuggestions((prev) => prev?.filter((s) => s.id !== id) ?? null);
+    setCount((c) => (c !== null ? c - 1 : null));
+  };
 
   return (
     <div className="border-t border-gray-100 mt-4 pt-4">
@@ -87,7 +107,7 @@ export default function SuggestPanel({ questionId, choices }: Props) {
         className="flex items-center justify-between w-full text-left group"
       >
         <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider group-hover:text-gray-500 transition-colors">
-          {t("alternatives")}{suggestions !== null ? ` (${count})` : ""}
+          {t("alternatives")}{count !== null ? ` (${count})` : ""}
         </span>
         {expanded ? (
           <ChevronUp size={14} className="text-gray-400" />
@@ -109,7 +129,7 @@ export default function SuggestPanel({ questionId, choices }: Props) {
           )}
 
           {!loading && suggestions?.map((s) => (
-            <SuggestionCard key={s.id} suggestion={s} t={t} />
+            <SuggestionCard key={s.id} suggestion={s} t={t} onDelete={handleDelete} onAdopt={handleAdopt} />
           ))}
 
           {successMsg && (
@@ -201,16 +221,43 @@ export default function SuggestPanel({ questionId, choices }: Props) {
 function SuggestionCard({
   suggestion,
   t,
+  onDelete,
+  onAdopt,
 }: {
   suggestion: Suggestion;
   t: (key: Parameters<typeof import("@/lib/i18n").t>[1]) => string;
+  onDelete: (id: number) => void;
+  onAdopt: (id: number) => void;
 }) {
+  const [deleting, setDeleting] = useState(false);
+  const [adopting, setAdopting] = useState(false);
+
   const isAi = suggestion.type === "ai";
   const author = suggestion.createdBy.split("@")[0];
-  const date = new Date(suggestion.createdAt).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
+  const rawDate = suggestion.createdAt;
+  const date = rawDate
+    ? new Date(rawDate).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+    : "";
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await fetch(`/api/suggestions/${suggestion.id}`, { method: "DELETE" });
+      onDelete(suggestion.id);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleAdopt = async () => {
+    setAdopting(true);
+    try {
+      await fetch(`/api/suggestions/${suggestion.id}/adopt`, { method: "POST" });
+      onAdopt(suggestion.id);
+    } finally {
+      setAdopting(false);
+    }
+  };
 
   return (
     <div className="border border-gray-100 rounded-xl p-3 space-y-2">
@@ -230,8 +277,24 @@ function SuggestionCard({
           <span className="text-[10px] text-gray-400">{suggestion.aiModel}</span>
         )}
         <span className="ml-auto text-[10px] text-gray-400">
-          {author} · {date}
+          {author}{date ? ` · ${date}` : ""}
         </span>
+        <button
+          onClick={handleAdopt}
+          disabled={adopting || deleting}
+          title="Adopt this suggestion"
+          className="p-1 rounded-lg text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 transition-colors disabled:opacity-40"
+        >
+          {adopting ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+        </button>
+        <button
+          onClick={handleDelete}
+          disabled={deleting || adopting}
+          title="Delete this suggestion"
+          className="p-1 rounded-lg text-gray-400 hover:text-rose-500 hover:bg-rose-50 transition-colors disabled:opacity-40"
+        >
+          {deleting ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />}
+        </button>
       </div>
 
       {/* Suggested answers */}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -856,6 +856,7 @@ export async function createSuggestion(
     aiModel: data.aiModel ?? null,
     comment: data.comment ?? null,
     createdBy,
+    createdAt: new Date().toISOString(),
   });
 
   // Fetch last inserted row (D1 doesn't support RETURNING reliably)
@@ -867,4 +868,33 @@ export async function createSuggestion(
 
   if (!row) throw new Error("Failed to retrieve created suggestion");
   return rowToSuggestion(row);
+}
+
+export async function getSuggestionCount(questionId: string): Promise<number> {
+  const db = getDrizzle();
+  if (!db) return 0;
+
+  const [row] = await db.select({ count: sql<number>`count(*)` })
+    .from(suggestionsTable)
+    .where(eq(suggestionsTable.questionId, questionId));
+
+  return row?.count ?? 0;
+}
+
+export async function getSuggestionById(id: number): Promise<Suggestion | null> {
+  const db = getDrizzle();
+  if (!db) return null;
+
+  const [row] = await db.select()
+    .from(suggestionsTable)
+    .where(eq(suggestionsTable.id, id));
+
+  return row ? rowToSuggestion(row) : null;
+}
+
+export async function deleteSuggestion(id: number): Promise<void> {
+  const db = getDrizzle();
+  if (!db) throw new Error("DB not available");
+
+  await db.delete(suggestionsTable).where(eq(suggestionsTable.id, id));
 }


### PR DESCRIPTION
## Summary
- Show alternative count in header (e.g. `ALTERNATIVES (3)`) before accordion is opened — fetches count eagerly on mount via `?count=1`
- Fix `createdAt` showing "Invalid Date" — `createSuggestion` now sets `createdAt: new Date().toISOString()` on insert
- Add adopt (✓) and delete (🗑) icon buttons to each suggestion card; adopt applies the suggestion's answers/explanation to the question via `POST /api/suggestions/[id]/adopt`

## Test plan
- [ ] Open a question reveal — header shows `ALTERNATIVES (N)` without opening accordion
- [ ] Open accordion — dates display correctly (e.g. "Mar 23")
- [ ] Click trash icon — suggestion disappears, count decrements
- [ ] Click check icon — question updated in DB, success toast shown, suggestion removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)