### PR TITLE
feat: audio replay button, answer sheets auto-advance, wrong mode snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,19 @@ This repository is worked on by **multiple AI agent teams in parallel** (e.g., C
 - **Cloudflare commit messages**: Cloudflare Pages API rejects non-ASCII characters in commit messages (error code 8000111). Keep commit messages in English/ASCII only.
 - **D1 migrations**: Production migrations are applied via `scripts/migrate-d1.sh` or wrangler. Verify the migration ran on production after deployment.
 
+## Debugging and Bug Fix Protocol
+
+When asked to fix a bug, follow this flow:
+
+1. **Specific fix**: Fix the reported location.
+2. **Pattern audit**: Search for the same root cause elsewhere.
+   - State reset omission → check all navigation callbacks (goNext/goPrev/useEffect)
+   - useEffect deps missing → check all effects sharing the same data dependency
+   - Async loading guard missing → check all empty-state renders for equivalent guards
+   - Memory leak → verify every resource allocation has a paired release
+3. **Fix all**: Include same-root-cause bugs found in step 2 in the same commit.
+4. **Report**: Explicitly tell the user which extra locations were fixed beyond the original request.
+
 ## UI Design System
 
 All components must follow these patterns consistently. Do not introduce new patterns without updating this section.

--- a/components/AnswersClient.tsx
+++ b/components/AnswersClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { ChevronLeft, ChevronRight, Sparkles, Wand2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Sparkles, Wand2, RotateCcw, Loader2 } from "lucide-react";
 import type { Question, QuizStats } from "@/lib/types";
 import QuestionEditModal from "./QuestionEditModal";
 import AiExplainPopup from "./AiExplainPopup";
@@ -43,7 +43,7 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
   const [filter, setFilter] = useState<"all" | "wrong">("all");
 
   const { settings, t } = useSettings();
-  const { speak, stop, prefetch } = useAudio();
+  const { speak, stop, prefetch, playing: audioPlaying, loading: audioLoading } = useAudio();
 
   // Load stats from localStorage and sync with DB
   useEffect(() => {
@@ -87,15 +87,21 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
     }
   }, [filteredQuestions.length, currentIndex]);
 
-  // Auto-play when question changes or audio is toggled on
+  // Auto-play when question changes; auto-advance to next when audio finishes
   useEffect(() => {
     const q = filteredQuestions[currentIndex];
     if (!q) return;
-    speak(buildAnswerText(q, settings.language));
     const next = filteredQuestions[currentIndex + 1];
     if (next) prefetch(buildAnswerText(next, settings.language)[0]);
-    return () => { stop(); };
-  }, [currentIndex, speak, stop, prefetch, settings.language, filteredQuestions]);
+    let cancelled = false;
+    speak(buildAnswerText(q, settings.language)).then(() => {
+      if (!cancelled && next && settings.audioMode) {
+        setCurrentIndex((i) => i + 1);
+      }
+    });
+    return () => { cancelled = true; stop(); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex, speak, stop, prefetch, settings.language, settings.audioMode]);
 
   const [aiPopupOpen, setAiPopupOpen] = useState(false);
   const [aiLoading, setAiLoading] = useState(false);
@@ -272,6 +278,12 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
   const goNext = useCallback(() => setCurrentIndex((i) => Math.min(i + 1, filteredQuestions.length - 1)), [filteredQuestions.length]);
   const goPrev = useCallback(() => setCurrentIndex((i) => Math.max(i - 1, 0)), []);
 
+  const handleReplay = useCallback(() => {
+    const q = filteredQuestions[currentIndex];
+    if (!q) return;
+    speak(buildAnswerText(q, settings.language));
+  }, [filteredQuestions, currentIndex, speak, settings.language]);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (editingQuestion || aiPopupOpen || refinePopupOpen) return;
@@ -322,6 +334,8 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
           filter={filter as "all" | "continue" | "wrong"}
           onFilterChange={(f) => setFilter(f === "continue" ? "all" : f)}
           wrongCount={wrongCount}
+          onReplay={handleReplay}
+          audioPlaying={audioPlaying || audioLoading}
         />
         <div className="flex-1 flex items-center justify-center text-sm text-gray-400">
           {t("noWrongAnswers")}

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft, AlertCircle,
-  CheckCircle2, XCircle, ChevronLeft, ChevronRight, Pencil, Sparkles, Wand2, Plus, Copy,
+  CheckCircle2, XCircle, ChevronLeft, ChevronRight, Pencil, Sparkles, Wand2, Plus, Copy, Loader2,
 } from "lucide-react";
 import type { Question, QuizStats } from "@/lib/types";
 import type { AiExplainResponse } from "@/app/api/ai/explain/route";
@@ -79,9 +79,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const [excludeDuplicates, setExcludeDuplicates] = useState(true);
   const [userInvalidated, setUserInvalidated] = useState<Set<string>>(() => new Set(initialInvalidatedIds));
 
-  // Wrong-filter fix: keep current question sticky until navigation, and skip index increment on removal
-  const submittedWrongQIdRef = useRef<number | null>(null);
-  const pendingWrongAdvanceRef = useRef(false);
+  const [wrongSnapshot, setWrongSnapshot] = useState<Set<number> | null>(null);
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [submitted, setSubmitted] = useState(false);
@@ -124,37 +122,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const touchZone = useRef<"top" | "bottom" | null>(null);
 
   const { settings, updateSettings, t } = useSettings();
-  const { speak, stop, prefetch } = useAudio();
-
-  // Auto-play question + choices when question changes or audio is toggled on
-  // Skip if answer is already revealed/submitted to avoid overlap with reveal effect
-  useEffect(() => {
-    if (revealed || submitted) return;
-    const q = filteredQuestions[currentIndex];
-    if (!q) return;
-    // 現在問題文の次から始まるチャンク列を k 個先読み
-    const next = filteredQuestions[currentIndex + 1];
-    const upcoming = [
-      buildQuestionText(q)[1],
-      buildAnswerRevealText(q, settings.language)[0],
-      ...(next ? [...buildQuestionText(next), buildAnswerRevealText(next, settings.language)[0]] : []),
-    ];
-    const k = settings.audioPrefetch ?? 3;
-    upcoming.slice(0, k).forEach((chunk) => prefetch(chunk));
-    speak(buildQuestionText(q));
-    return () => { stop(); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentIndex, mode, speak, stop, prefetch, revealed, submitted, settings.language]);
-
-  // Auto-play answer reveal when card is flipped (review) or submitted (quiz)
-  useEffect(() => {
-    if (!revealed && !submitted) return;
-    const q = filteredQuestions[currentIndex];
-    if (!q) return;
-    stop();
-    speak(buildAnswerRevealText(q, settings.language));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [revealed, submitted, speak, stop, settings.language, currentIndex]);
+  const { speak, stop, prefetch, playing: audioPlaying } = useAudio();
 
   const backHref = `/exam/${examId}`;
 
@@ -201,6 +169,10 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   }, [currentIndex, filter, mode]);
 
   useEffect(() => {
+    if (filter === "wrong") {
+      setDirection("forward");
+      return; // Snapshot effect handles index for wrong mode
+    }
     if (filter === "continue") {
       const savedId = loadLastQuestionId(examId);
       if (savedId !== null) {
@@ -219,17 +191,70 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filter, excludeDuplicates]);
 
+  // Snapshot effect: freeze wrong-mode question list on first load to avoid questions disappearing mid-session
+  useEffect(() => {
+    if (filter === "wrong" && statsLoaded && wrongSnapshot === null) {
+      const snap = new Set(
+        questions.filter((q) => stats[String(q.id)] === 0).map((q) => q.id)
+      );
+      setWrongSnapshot(snap);
+      if (initialQuestionId !== undefined) {
+        const snapQuestions = questions.filter((q) => snap.has(q.id));
+        const idx = snapQuestions.findIndex((q) => q.id === initialQuestionId);
+        setCurrentIndex(idx >= 0 ? idx : 0);
+      } else {
+        setCurrentIndex(0);
+      }
+    }
+    if (filter !== "wrong") {
+      setWrongSnapshot(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter, statsLoaded]);
+
   const duplicateCount = questions.filter((q) => q.isDuplicate).length;
 
   const filteredQuestions = questions.filter((q) => {
     if (userInvalidated.has(q.dbId)) return false;
     if (filter === "wrong") {
-      if (q.id === submittedWrongQIdRef.current) return true; // keep during reveal until navigation
-      return stats[String(q.id)] === 0;
+      return wrongSnapshot ? wrongSnapshot.has(q.id) : stats[String(q.id)] === 0;
     }
     if (excludeDuplicates && q.isDuplicate) return false;
     return true;
   });
+
+  // currentQId enables re-fire when invalidate replaces same-index question without index change
+  const currentQId = filteredQuestions[currentIndex]?.id;
+
+  // Auto-play question + choices when question changes or audio is toggled on
+  // Skip if answer is already revealed/submitted to avoid overlap with reveal effect
+  useEffect(() => {
+    if (revealed || submitted) return;
+    const q = filteredQuestions[currentIndex];
+    if (!q) return;
+    // 現在問題文の次から始まるチャンク列を k 個先読み
+    const next = filteredQuestions[currentIndex + 1];
+    const upcoming = [
+      buildQuestionText(q)[1],
+      buildAnswerRevealText(q, settings.language)[0],
+      ...(next ? [...buildQuestionText(next), buildAnswerRevealText(next, settings.language)[0]] : []),
+    ];
+    const k = settings.audioPrefetch ?? 3;
+    upcoming.slice(0, k).forEach((chunk) => prefetch(chunk));
+    speak(buildQuestionText(q));
+    return () => { stop(); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex, currentQId, mode, speak, stop, prefetch, revealed, submitted, settings.language]);
+
+  // Auto-play answer reveal when card is flipped (review) or submitted (quiz)
+  useEffect(() => {
+    if (!revealed && !submitted) return;
+    const q = filteredQuestions[currentIndex];
+    if (!q) return;
+    stop();
+    speak(buildAnswerRevealText(q, settings.language));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealed, submitted, speak, stop, settings.language, currentIndex]);
 
   // Save current question position whenever index changes
   useEffect(() => {
@@ -255,22 +280,22 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   useEffect(() => {
     if (filteredQuestions.length > 0 && currentIndex >= filteredQuestions.length) {
       setCurrentIndex(filteredQuestions.length - 1);
+      setDirection("forward");
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filteredQuestions.length]);
 
-  // Auto-reset "wrong" filter when all wrong answers are cleared
+  // Show toast when all snapshot questions are answered correctly (but keep filter active)
   useEffect(() => {
-    if (!statsLoaded) return;
-    if (filter === "wrong" && wrongCount === 0) {
-      setFilter("all");
-      setCurrentIndex(0);
+    if (!statsLoaded || filter !== "wrong" || !wrongSnapshot || wrongSnapshot.size === 0) return;
+    const allDone = [...wrongSnapshot].every((id) => stats[String(id)] === 1);
+    if (allDone) {
       setFilterResetToast(true);
       const timer = setTimeout(() => setFilterResetToast(false), 3000);
       return () => clearTimeout(timer);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wrongCount, statsLoaded]);
+  }, [stats, wrongSnapshot, statsLoaded, filter]);
 
 
   const recordAnswer = useCallback((questionId: number, correct: boolean, questionDbId: string, srsQuality?: 1 | 4) => {
@@ -313,10 +338,6 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     const correct = q.answers.length === selected.size && q.answers.every((a) => selected.has(a));
     setIsCorrect(correct);
     if (!correct) setShakeKey((k) => k + 1);
-    if (filter === "wrong" && correct) {
-      submittedWrongQIdRef.current = q.id;
-      pendingWrongAdvanceRef.current = true;
-    }
     recordAnswer(q.id, correct, q.dbId);
     if (mode !== "review") {
       setStreak((prev) => correct ? prev + 1 : 0);
@@ -329,22 +350,16 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   }, [filteredQuestions, currentIndex, filter, selected, recordAnswer, mode, settings.skipRevealOnCorrect]);
 
   const goNext = useCallback(() => {
-    const skipAdvance = pendingWrongAdvanceRef.current;
-    pendingWrongAdvanceRef.current = false;
-    submittedWrongQIdRef.current = null;
+    setIsCorrect(null);
     setDirection("forward");
     setRevealed(false);
     setSubmitted(false);
     setSelected(new Set());
-    if (!skipAdvance) {
-      setCurrentIndex((i) => Math.min(i + 1, filteredQuestions.length - 1));
-    }
-    // skipAdvance=true: sticky cleared → filteredQuestions shrinks → currentIndex unchanged → points to next Q
+    setCurrentIndex((i) => Math.min(i + 1, filteredQuestions.length - 1));
   }, [filteredQuestions.length]);
 
   const goPrev = useCallback(() => {
-    pendingWrongAdvanceRef.current = false;
-    submittedWrongQIdRef.current = null;
+    setIsCorrect(null);
     setDirection("backward");
     setCurrentIndex((i) => Math.max(i - 1, 0));
     setRevealed(false);
@@ -373,10 +388,6 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
   const handleKnow = useCallback(() => {
     const q = filteredQuestions[currentIndex];
     if (!q) return;
-    if (filter === "wrong") {
-      submittedWrongQIdRef.current = q.id;
-      pendingWrongAdvanceRef.current = true;
-    }
     recordAnswer(q.id, true, q.dbId, 4);
     setStreak((prev) => prev + 1);
     if (currentIndex === filteredQuestions.length - 1) {
@@ -385,7 +396,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     } else {
       goNext();
     }
-  }, [filteredQuestions, currentIndex, filter, recordAnswer, goNext, router, backHref, doCompleteSession]);
+  }, [filteredQuestions, currentIndex, recordAnswer, goNext, router, backHref, doCompleteSession]);
 
   const handleDontKnow = useCallback(() => {
     const q = filteredQuestions[currentIndex];
@@ -646,6 +657,24 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
 
   const showAnswerModal = mode === "quiz" && submitted;
 
+  const handleReplay = useCallback(() => {
+    const q = filteredQuestions[currentIndex];
+    if (!q) return;
+    if (revealed || submitted) {
+      speak(buildAnswerRevealText(q, settings.language));
+    } else {
+      speak(buildQuestionText(q));
+    }
+  }, [filteredQuestions, currentIndex, revealed, submitted, speak, settings.language]);
+
+  if (!statsLoaded) {
+    return (
+      <div className="h-screen flex items-center justify-center">
+        <Loader2 className="animate-spin text-gray-300" size={24} />
+      </div>
+    );
+  }
+
   if (filteredQuestions.length === 0) {
     const isAllCleared = filter === "wrong";
     return (
@@ -708,6 +737,8 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
         duplicateCount={duplicateCount}
         excludeDuplicates={excludeDuplicates}
         onToggleDuplicates={() => setExcludeDuplicates((v) => !v)}
+        onReplay={handleReplay}
+        audioPlaying={audioPlaying}
       />
 
       {/* ── Main ── */}

--- a/components/QuizHeader.tsx
+++ b/components/QuizHeader.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import {
   ArrowLeft, Home, Brain, BookOpen, BookOpenCheck, ClipboardList,
   Layers, AlertCircle, History, Copy, Globe, Volume2, VolumeOff,
-  Loader2, Settings, Zap,
+  Loader2, Settings, Zap, RotateCcw,
 } from "lucide-react";
 import { LANG_OPTIONS } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings-context";
@@ -39,6 +39,10 @@ interface QuizHeaderProps {
   excludeDuplicates?: boolean;
   onToggleDuplicates?: () => void;
 
+  // Audio replay
+  onReplay?: () => void;
+  audioPlaying?: boolean;
+
   // Custom right slot (e.g. timer for Mock)
   rightExtra?: React.ReactNode;
 }
@@ -70,6 +74,8 @@ export default function QuizHeader({
   duplicateCount = 0,
   excludeDuplicates,
   onToggleDuplicates,
+  onReplay,
+  audioPlaying,
   rightExtra,
 }: QuizHeaderProps) {
   const { settings, updateSettings, t } = useSettings();
@@ -222,6 +228,19 @@ export default function QuizHeader({
             </div>
           )}
         </div>
+
+        {/* Audio replay button */}
+        {settings.audioMode && onReplay && (
+          <button
+            onClick={onReplay}
+            className="p-1.5 rounded-lg transition-colors text-gray-300 hover:text-sky-500 hover:bg-gray-100"
+            title="Replay audio"
+          >
+            {audioPlaying
+              ? <Loader2 size={13} className="animate-spin text-sky-400" />
+              : <RotateCcw size={13} />}
+          </button>
+        )}
 
         {/* Audio toggle */}
         <button

--- a/hooks/useAudio.ts
+++ b/hooks/useAudio.ts
@@ -5,6 +5,7 @@ import { useSettings } from "@/lib/settings-context";
 import { makeCacheKey, getAudioBlob, setAudioBlob } from "@/lib/audioDb";
 
 // Session-scoped cache: text → Object URL (WAV blob)
+const AUDIO_CACHE_MAX = 100;
 const audioCache = new Map<string, string>();
 // In-flight dedup: text → pending promise
 const inFlight = new Map<string, Promise<string | null>>();
@@ -55,6 +56,12 @@ export function useAudio() {
         const blob = await res.blob();
         const objectUrl = URL.createObjectURL(blob);
         audioCache.set(text, objectUrl);
+        if (audioCache.size > AUDIO_CACHE_MAX) {
+          const firstKey = audioCache.keys().next().value!;
+          const evictedUrl = audioCache.get(firstKey);
+          if (evictedUrl) URL.revokeObjectURL(evictedUrl);
+          audioCache.delete(firstKey);
+        }
         if (cacheKey) {
           setAudioBlob(cacheKey, blob).catch(() => {});
         }


### PR DESCRIPTION
## Summary

- **#1 Audio replay**: `RotateCcw` button in QuizHeader (audioMode on only); QuizClient & AnswersClient each wire up an `onReplay` callback
- **#2 Answer sheets auto-advance**: `speak().then()` advances to next question in audioMode; `cancelled` flag prevents double-advance on manual navigation
- **#3 Invalidate audio fix**: `currentQId` added to audio `useEffect` deps so audio re-fires when same-index question is replaced after invalidation
- **#4 Correct animation bleed**: `setIsCorrect(null)` in `goNext`/`goPrev` stops green/red background carrying over to the next question
- **#5 Wrong mode snapshot**: `wrongSnapshot` freezes the wrong-question list at filter-activation time; completion shows toast without auto-resetting filter
- **#6 Wrong mode + settings flash**: `if (!statsLoaded) return <spinner>` added before empty-state to prevent "All cleared!" flash on initial load
- **#7 Direction on clamp**: `setDirection("forward")` added to clamp `useEffect`
- **#8 Object URL leak**: `audioCache` evicts oldest entry with `URL.revokeObjectURL` when size > 100
- Added **Debugging and Bug Fix Protocol** to `CLAUDE.md`

## Test plan

- [ ] audioMode ON → RotateCcw button appears in header; click replays current question/answer
- [ ] Answer sheets + audioMode ON → audio finishes → auto-advances to next question
- [ ] Invalidate a question → next question's audio plays correctly
- [ ] `skipRevealOnCorrect=true` → next question starts with white background (no green bleed)
- [ ] Wrong mode → question list frozen at session start; correct answers stay visible (green); completion toast fires without resetting filter
- [ ] Wrong mode → open settings → return → no "All cleared!" flash; resumes correct question
- [ ] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)