### PR TITLE
fix: settings page crash when aiPromptVersions is not an array

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -643,12 +643,21 @@ export async function getAllUserSettings(userEmail: string): Promise<UserSetting
   const raw: Partial<UserSettings> = {};
   for (const row of rows) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (row.key === "dailyGoal" || row.key === "audioSpeed") {
+    if (row.key === "dailyGoal" || row.key === "audioSpeed" || row.key === "audioPrefetch") {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (raw as any)[row.key] = Number(row.value);
-    } else if (row.key === "audioMode") {
+    } else if (row.key === "audioMode" || row.key === "skipRevealOnCorrect") {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (raw as any)[row.key] = row.value === "true" || row.value === "1";
+    } else if (row.key === "aiPromptVersions" || row.key === "aiRefinePromptVersions" || row.key === "studyGuidePromptVersions") {
+      try {
+        const parsed = JSON.parse(row.value);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (raw as any)[row.key] = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (raw as any)[row.key] = [];
+      }
     } else {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (raw as any)[row.key] = row.value;
@@ -658,6 +667,9 @@ export async function getAllUserSettings(userEmail: string): Promise<UserSetting
   if (!merged.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
   if (!merged.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
   if (!merged.studyGuidePrompt) merged.studyGuidePrompt = DEFAULT_USER_SETTINGS.studyGuidePrompt;
+  if (!Array.isArray(merged.aiPromptVersions)) merged.aiPromptVersions = [];
+  if (!Array.isArray(merged.aiRefinePromptVersions)) merged.aiRefinePromptVersions = [];
+  if (!Array.isArray(merged.studyGuidePromptVersions)) merged.studyGuidePromptVersions = [];
   return merged;
 }
 
@@ -666,14 +678,17 @@ export async function setUserSettings(userEmail: string, settings: Partial<UserS
   if (!db) return;
 
   for (const [key, value] of Object.entries(settings)) {
+    const serialized = (Array.isArray(value) || (typeof value === "object" && value !== null))
+      ? JSON.stringify(value)
+      : String(value);
     await db.insert(userSettings)
       .values({
-        userEmail, key, value: String(value),
+        userEmail, key, value: serialized,
         updatedAt: sql`datetime('now')` as unknown as string,
       })
       .onConflictDoUpdate({
         target: [userSettings.userEmail, userSettings.key],
-        set: { value: String(value), updatedAt: sql`datetime('now')` },
+        set: { value: serialized, updatedAt: sql`datetime('now')` },
       });
   }
 }

--- a/lib/settings-context.tsx
+++ b/lib/settings-context.tsx
@@ -27,6 +27,9 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
         const merged: UserSettings = { ...DEFAULT_USER_SETTINGS, ...remote };
         if (!merged.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
         if (!merged.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+        if (!Array.isArray(merged.aiPromptVersions)) merged.aiPromptVersions = [];
+        if (!Array.isArray(merged.aiRefinePromptVersions)) merged.aiRefinePromptVersions = [];
+        if (!Array.isArray(merged.studyGuidePromptVersions)) merged.studyGuidePromptVersions = [];
         setSettings(merged);
         // Sync to localStorage as cache
         try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch { /* ignore */ }
@@ -40,6 +43,9 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
             const merged = { ...DEFAULT_USER_SETTINGS, ...parsed };
             if (!parsed.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
             if (!parsed.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+            if (!Array.isArray(merged.aiPromptVersions)) merged.aiPromptVersions = [];
+            if (!Array.isArray(merged.aiRefinePromptVersions)) merged.aiRefinePromptVersions = [];
+            if (!Array.isArray(merged.studyGuidePromptVersions)) merged.studyGuidePromptVersions = [];
             setSettings(merged);
           }
         } catch { /* ignore */ }


### PR DESCRIPTION
## Summary

- `/settings` ページが `r.map is not a function` でクラッシュするバグを修正
- `aiPromptVersions` / `aiRefinePromptVersions` / `studyGuidePromptVersions` が DB に `String(value)` で保存されており、読み出し時にパースされていなかったため、配列ではなく文字列 `"[object Object],[object Object]"` がセットされていた

## Changes

- `lib/db.ts` `getAllUserSettings`: 配列型キーを `JSON.parse` + `Array.isArray` チェックで復元
- `lib/db.ts` `setUserSettings`: 配列/オブジェクト値を `JSON.stringify` でシリアライズ
- `lib/settings-context.tsx`: マージ後に配列ガードを追加
- ついでに `audioPrefetch`（数値）と `skipRevealOnCorrect`（真偽値）の型変換も修正

## Test plan

- [ ] `/settings` を開いてプロンプト編集セクションが表示されることを確認
- [ ] バージョン保存 → リロード後も保持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)