### PR TITLE
fix: guard all keydown handlers against IME composition Enter

### DIFF
--- a/components/AiExplainPopup.tsx
+++ b/components/AiExplainPopup.tsx
@@ -55,6 +55,7 @@ export default function AiExplainPopup({
   useEffect(() => {
     if (!result || loading) return;
     const handler = (e: KeyboardEvent) => {
+      if (e.isComposing) return;
       if (e.target === inputRef.current) return; // don't intercept chat input
       if (e.key === "Enter" && !adopting) { e.preventDefault(); onAdopt(); }
       if (e.key === "Backspace" || e.key === "Escape") { e.preventDefault(); onDismiss(); }
@@ -230,7 +231,7 @@ export default function AiExplainPopup({
               value={chatInput}
               onChange={(e) => setChatInput(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
+                if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
                   e.preventDefault();
                   handleChatSend();
                 }

--- a/components/AnswerRevealModal.tsx
+++ b/components/AnswerRevealModal.tsx
@@ -21,7 +21,7 @@ export default function AnswerRevealModal({ question, isCorrect, isLast, onNext,
     const ready = Date.now();
     const handler = (e: KeyboardEvent) => {
       if (Date.now() - ready < 150) return;
-      if (e.key === "Escape" || e.key === "n" || e.key === "N" || e.key === "Enter" || e.key === "ArrowRight") {
+      if (!e.isComposing && (e.key === "Escape" || e.key === "n" || e.key === "N" || e.key === "Enter" || e.key === "ArrowRight")) {
         e.preventDefault();
         onNext();
       }

--- a/components/ExamDetailClient.tsx
+++ b/components/ExamDetailClient.tsx
@@ -149,7 +149,7 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats }: 
               onChange={(e) => setExamName(e.target.value)}
               className="flex-1 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:border-transparent"
               placeholder="Exam name"
-              onKeyDown={(e) => { if (e.key === "Enter") saveExamMeta(); if (e.key === "Escape") cancelEditMeta(); }}
+              onKeyDown={(e) => { if (e.key === "Enter" && !e.isComposing) saveExamMeta(); if (e.key === "Escape") cancelEditMeta(); }}
             />
             <div className="flex items-center gap-0.5 bg-gray-100 rounded-lg p-0.5">
               {(["ja", "en"] as const).map((lang) => (

--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -545,6 +545,7 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
     const labels = q.choices.map((c) => c.label);
 
     const handler = (e: KeyboardEvent) => {
+      if (e.isComposing) return;
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       if (editingQuestion || aiPopupOpen || refinePopupOpen) return;
       if (mode === "quiz" && submitted) return; // modal handles keys


### PR DESCRIPTION
## Summary
- Guards all keydown handlers against IME composition Enter key events to prevent double-submit on Japanese/Chinese/Korean input

## Test plan
- [ ] `npm run build` passes
- [ ] Quiz screen: type with IME, confirm Enter does not trigger answer during composition