### PR TITLE
fix: show question source in quiz and flashcard modes

### DIFF
--- a/components/QuizClient.tsx
+++ b/components/QuizClient.tsx
@@ -765,6 +765,11 @@ export default function QuizClient({ questions: initialQuestions, examId, examNa
                               className="text-gray-900 text-sm lg:text-base leading-relaxed font-medium whitespace-pre-wrap [&_img]:max-w-full [&_img]:rounded-lg [&_img]:mt-2"
                               dangerouslySetInnerHTML={{ __html: q.question }}
                             />
+                            {q.source && (
+                              <p className="text-[10px] text-gray-300 mt-2 truncate" title={q.source}>
+                                Source: {q.source}
+                              </p>
+                            )}
                           </div>
                           <div className="space-y-2">
                             {q.choices.map((c, i) => (

--- a/components/QuizQuestion.tsx
+++ b/components/QuizQuestion.tsx
@@ -46,6 +46,11 @@ export default function QuizQuestion({
           className="text-gray-900 text-sm lg:text-base leading-relaxed font-medium whitespace-pre-wrap [&_img]:max-w-full [&_img]:rounded-lg [&_img]:mt-2"
           dangerouslySetInnerHTML={{ __html: question.question }}
         />
+        {question.source && (
+          <p className="text-[10px] text-gray-300 mt-2 truncate" title={question.source}>
+            Source: {question.source}
+          </p>
+        )}
       </div>
 
       {/* Choices — scrollable if many */}


### PR DESCRIPTION
## Summary
- Displays the question source attribution in quiz and flashcard mode question boxes

## Test plan
- [ ] `npm run build` passes
- [ ] Question source visible in quiz and flashcard views