### PR TITLE
fix: add edge runtime to /api/feedback for Cloudflare Pages

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "edge";
+
 interface ImagePayload {
   name: string;
   data: string;


### PR DESCRIPTION
Cloudflare Pages は全 API route に `export const runtime = 'edge'` が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)