### PR TITLE
fix: set daily goal fallback default to 100

### DIFF
--- a/components/ExamListClient.tsx
+++ b/components/ExamListClient.tsx
@@ -345,7 +345,7 @@ export default function ExamListClient({ exams: initialExams }: Props) {
 
       {/* Daily progress banner */}
       {dailyProgress && (dailyProgress.todayCount > 0 || dailyProgress.streak > 0) && (() => {
-        const goal = settings.dailyGoal ?? 20;
+        const goal = settings.dailyGoal ?? 100;
         const { todayCount, streak } = dailyProgress;
         const pct = Math.min(100, Math.round((todayCount / goal) * 100));
         const done = todayCount >= goal;


### PR DESCRIPTION
## Summary
- `lib/types.ts` already defines `dailyGoal: 100` as the default value
- `ExamListClient.tsx` had a stale `?? 20` fallback that was overriding the correct default

## Test plan
- [ ] Visit exam list page — daily progress bar should calculate against 100 (not 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)