### PR TITLE
fix: show TTS replay button in answers header

### DIFF
--- a/components/AnswersClient.tsx
+++ b/components/AnswersClient.tsx
@@ -359,6 +359,8 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
         filter={filter as "all" | "continue" | "wrong" | "custom"}
         onFilterChange={(f) => setFilter(f === "continue" || f === "custom" ? "all" : f)}
         wrongCount={wrongCount}
+        onReplay={handleReplay}
+        audioPlaying={audioPlaying || audioLoading}
       />
 
       {/* Main */}


### PR DESCRIPTION
## Summary
- The answers page has two `QuizHeader` renders (empty-state and main)
- The empty-state header correctly passed `onReplay`, but the main header (shown when viewing questions) did not
- This caused the replay button to be invisible when audio mode was on

## Test plan
- [ ] Enable audio mode in settings
- [ ] Open an exam in Answers mode
- [ ] Verify the replay (↺) button appears in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)