### PR TITLE
feat: move AI Fill from quiz header to exam detail page

### DIFF
--- a/components/ExamDetailClient.tsx
+++ b/components/ExamDetailClient.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import Link from "next/link";
 import {
   Brain, BookOpen, BookOpenCheck,
   ChevronRight, AlertCircle, TrendingUp, Tag, Timer, History,
-  Pencil, Check, X, Lightbulb, Languages,
+  Pencil, Check, X, Lightbulb, Languages, Sparkles, Loader2,
 } from "lucide-react";
 import type { CategoryStat, ExamMeta } from "@/lib/types";
 import { useSetHeader } from "@/lib/header-context";
@@ -31,7 +31,7 @@ function pctTextColor(pct: number) {
 }
 
 export default function ExamDetailClient({ exam, categoryStats: initialStats, userEmail }: Props) {
-  const { t } = useSettings();
+  const { settings, t } = useSettings();
   const [stats, setStats] = useState<CategoryStat[]>(initialStats);
   const [statsLoading, setStatsLoading] = useState(true);
   const [selectedMode, setSelectedMode] = useState<"quiz" | "review">("quiz");
@@ -70,6 +70,47 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats, us
   const [translateProgress, setTranslateProgress] = useState<{ done: number; total: number } | null>(null);
   const [translateError, setTranslateError] = useState<string | null>(null);
   const [newExamId, setNewExamId] = useState<string | null>(null);
+
+  // AI Fill
+  const [fillStatus, setFillStatus] = useState<"idle" | "filling" | "done" | "error">("idle");
+  const [fillProgress, setFillProgress] = useState<{ done: number; total: number } | null>(null);
+  const [fillResult, setFillResult] = useState<{ filled: number; skipped: number } | null>(null);
+
+  const startFill = useCallback(async () => {
+    setFillStatus("filling");
+    setFillProgress(null);
+    setFillResult(null);
+    try {
+      const res = await fetch(`/api/admin/exams/${encodeURIComponent(exam.id)}/fill`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userPrompt: settings.aiFillPrompt }),
+      });
+      if (!res.body) { setFillStatus("error"); return; }
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        const parts = buf.split("\n\n");
+        buf = parts.pop() ?? "";
+        for (const part of parts) {
+          if (!part.startsWith("data: ")) continue;
+          const evt = JSON.parse(part.slice(6)) as { error?: string; done?: number; total?: number; filled?: number; skipped?: number };
+          if (evt.error) { setFillStatus("error"); return; }
+          if (evt.total !== undefined) setFillProgress({ done: evt.done ?? 0, total: evt.total });
+          if (evt.filled !== undefined) setFillResult({ filled: evt.filled, skipped: evt.skipped ?? 0 });
+        }
+      }
+      setFillStatus("done");
+      setTimeout(() => { setFillStatus("idle"); setFillResult(null); }, 4000);
+    } catch {
+      setFillStatus("error");
+      setTimeout(() => setFillStatus("idle"), 3000);
+    }
+  }, [exam.id, settings.aiFillPrompt]);
 
   useEffect(() => {
     if (editingMeta) nameInputRef.current?.focus();
@@ -590,6 +631,34 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats, us
                   <Languages size={14} /> 翻訳して作成
                 </button>
               )}
+            </div>
+
+            {/* AI Fill */}
+            <div className="border-t border-gray-100 pt-3">
+              <button
+                onClick={fillStatus === "idle" ? startFill : undefined}
+                disabled={fillStatus === "filling"}
+                title={
+                  fillStatus === "filling" ? (fillProgress ? `Filling ${fillProgress.done}/${fillProgress.total}…` : "Starting…")
+                  : fillStatus === "done" ? (fillResult ? `Filled ${fillResult.filled} · Skipped ${fillResult.skipped}` : "Done")
+                  : fillStatus === "error" ? "Fill failed — click to retry"
+                  : "Fill missing answers, explanations and categories with AI"
+                }
+                className={`w-full h-10 rounded-xl border text-sm font-medium transition-colors flex items-center justify-center gap-1.5 ${
+                  fillStatus === "filling" ? "border-sky-200 text-sky-500 bg-sky-50"
+                  : fillStatus === "done" ? "border-emerald-200 text-emerald-600 bg-emerald-50"
+                  : fillStatus === "error" ? "border-rose-200 text-rose-500 bg-rose-50"
+                  : "border-gray-200 text-gray-500 hover:bg-gray-50"
+                }`}
+              >
+                {fillStatus === "filling"
+                  ? <><Loader2 size={14} className="animate-spin" /> AI Fill {fillProgress ? `${fillProgress.done}/${fillProgress.total}` : "…"}</>
+                  : fillStatus === "done"
+                  ? <><Sparkles size={14} /> {fillResult ? `Filled ${fillResult.filled} · Skipped ${fillResult.skipped}` : "Done"}</>
+                  : fillStatus === "error"
+                  ? <><Sparkles size={14} /> Fill failed</>
+                  : <><Sparkles size={14} /> AI Fill</>}
+              </button>
             </div>
 
             {/* Translation panel */}

--- a/components/QuizHeader.tsx
+++ b/components/QuizHeader.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import {
   ArrowLeft, Home, Brain, BookOpen, BookOpenCheck, ClipboardList,
   Layers, AlertCircle, History, Copy, Globe, Volume2, VolumeOff,
-  Loader2, Settings, Zap, RotateCcw, SlidersHorizontal, Sparkles,
+  Loader2, Settings, Zap, RotateCcw, SlidersHorizontal,
 } from "lucide-react";
 import { LANG_OPTIONS } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings-context";
@@ -95,46 +95,6 @@ export default function QuizHeader({
   const { settings, updateSettings, t } = useSettings();
   const { loading: audioLoading } = useAudio();
   const backHref = `/exam/${encodeURIComponent(examId)}`;
-
-  const [fillStatus, setFillStatus] = useState<"idle" | "filling" | "done" | "error">("idle");
-  const [fillProgress, setFillProgress] = useState<{ done: number; total: number } | null>(null);
-  const [fillResult, setFillResult] = useState<{ filled: number; skipped: number } | null>(null);
-
-  const startFill = useCallback(async () => {
-    setFillStatus("filling");
-    setFillProgress(null);
-    setFillResult(null);
-    try {
-      const res = await fetch(`/api/admin/exams/${examId}/fill`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userPrompt: settings.aiFillPrompt }),
-      });
-      if (!res.body) { setFillStatus("error"); return; }
-      const reader = res.body.getReader();
-      const dec = new TextDecoder();
-      let buf = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += dec.decode(value, { stream: true });
-        const parts = buf.split("\n\n");
-        buf = parts.pop() ?? "";
-        for (const part of parts) {
-          if (!part.startsWith("data: ")) continue;
-          const evt = JSON.parse(part.slice(6)) as { error?: string; done?: number; total?: number; filled?: number; skipped?: number };
-          if (evt.error) { setFillStatus("error"); return; }
-          if (evt.total !== undefined) setFillProgress({ done: evt.done ?? 0, total: evt.total });
-          if (evt.filled !== undefined) setFillResult({ filled: evt.filled, skipped: evt.skipped ?? 0 });
-        }
-      }
-      setFillStatus("done");
-      setTimeout(() => { setFillStatus("idle"); setFillResult(null); }, 4000);
-    } catch {
-      setFillStatus("error");
-      setTimeout(() => setFillStatus("idle"), 3000);
-    }
-  }, [examId, settings.aiFillPrompt]);
 
   const [langOpen, setLangOpen] = useState(false);
   const langRef = useRef<HTMLDivElement>(null);
@@ -351,28 +311,6 @@ export default function QuizHeader({
             : settings.audioMode
             ? <Volume2 size={13} className="text-sky-500" />
             : <VolumeOff size={13} />}
-        </button>
-
-        {/* AI Fill */}
-        <button
-          onClick={fillStatus === "idle" ? startFill : undefined}
-          disabled={fillStatus === "filling"}
-          title={
-            fillStatus === "filling" ? (fillProgress ? `Filling ${fillProgress.done}/${fillProgress.total}…` : "Starting…")
-            : fillStatus === "done" ? (fillResult ? `Filled ${fillResult.filled} · Skipped ${fillResult.skipped}` : "Done")
-            : fillStatus === "error" ? "Fill failed"
-            : "Fill missing fields with AI"
-          }
-          className={`p-1.5 rounded-lg transition-colors ${
-            fillStatus === "filling" ? "text-sky-400 hover:bg-gray-100"
-            : fillStatus === "done" ? "text-emerald-500 hover:bg-gray-100"
-            : fillStatus === "error" ? "text-rose-400 hover:bg-gray-100"
-            : "text-gray-300 hover:text-gray-600 hover:bg-gray-100"
-          }`}
-        >
-          {fillStatus === "filling"
-            ? <Loader2 size={13} className="animate-spin" />
-            : <Sparkles size={13} />}
         </button>
 
         {/* Settings */}

--- a/lib/settings-context.tsx
+++ b/lib/settings-context.tsx
@@ -27,9 +27,11 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
         const merged: UserSettings = { ...DEFAULT_USER_SETTINGS, ...remote };
         if (!merged.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
         if (!merged.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+        if (!merged.aiFillPrompt) merged.aiFillPrompt = DEFAULT_USER_SETTINGS.aiFillPrompt;
         if (!Array.isArray(merged.aiPromptVersions)) merged.aiPromptVersions = [];
         if (!Array.isArray(merged.aiRefinePromptVersions)) merged.aiRefinePromptVersions = [];
         if (!Array.isArray(merged.studyGuidePromptVersions)) merged.studyGuidePromptVersions = [];
+        if (!Array.isArray(merged.aiFillPromptVersions)) merged.aiFillPromptVersions = [];
         setSettings(merged);
         // Sync to localStorage as cache
         try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch { /* ignore */ }
@@ -43,9 +45,11 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
             const merged = { ...DEFAULT_USER_SETTINGS, ...parsed };
             if (!parsed.aiPrompt) merged.aiPrompt = DEFAULT_USER_SETTINGS.aiPrompt;
             if (!parsed.aiRefinePrompt) merged.aiRefinePrompt = DEFAULT_USER_SETTINGS.aiRefinePrompt;
+            if (!parsed.aiFillPrompt) merged.aiFillPrompt = DEFAULT_USER_SETTINGS.aiFillPrompt;
             if (!Array.isArray(merged.aiPromptVersions)) merged.aiPromptVersions = [];
             if (!Array.isArray(merged.aiRefinePromptVersions)) merged.aiRefinePromptVersions = [];
             if (!Array.isArray(merged.studyGuidePromptVersions)) merged.studyGuidePromptVersions = [];
+            if (!Array.isArray(merged.aiFillPromptVersions)) merged.aiFillPromptVersions = [];
             setSettings(merged);
           }
         } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- **Removed** AI Fill (✨) button from `QuizHeader` — it was appearing on every quiz/review/answers page, far from the content it acts on
- **Added** AI Fill button to `ExamDetailClient` (/exam/[id]), below the Translate button, showing inline progress (filling N/total) and result (filled X · skipped Y)
- **Fixed** `settings-context.tsx`: guard `aiFillPrompt` and `aiFillPromptVersions` with defaults during merge, matching the existing pattern for other prompt fields

## Test plan
- [ ] Open any exam in quiz/review/answers mode — verify no ✨ button in header
- [ ] Open /exam/[id] — verify AI Fill button appears below Translate
- [ ] Click AI Fill — verify progress shows and result appears on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)