### PR TITLE
fix: bulk ops reliability -- per-question save, skip flags, answers edit button

### DIFF
--- a/app/api/admin/exams/[id]/fill/route.ts
+++ b/app/api/admin/exams/[id]/fill/route.ts
@@ -1,0 +1,194 @@
+export const runtime = "edge";
+
+import { NextRequest } from "next/server";
+import { GoogleGenAI } from "@google/genai";
+import { getDB, getSetting } from "@/lib/db";
+import { getRequestContext } from "@cloudflare/next-on-pages";
+import { DEFAULT_FILL_PROMPT } from "@/lib/types";
+import type { Choice } from "@/lib/types";
+
+interface FillResult {
+  id: string;
+  answers: string[];
+  explanation: string;
+  category: string;
+}
+
+interface QuestionRow {
+  id: string;
+  question_text: string;
+  options: string;
+  answers: string;
+  explanation: string;
+  category: string | null;
+  filled_at: string | null;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: examId } = await params;
+  let userPrompt: string | undefined;
+  let forceRefill = false;
+  try {
+    const body = await req.json() as { userPrompt?: string; forceRefill?: boolean };
+    userPrompt = body.userPrompt;
+    forceRefill = body.forceRefill ?? false;
+  } catch { /* no body is fine */ }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ctx = getRequestContext() as any;
+  const apiKey = ctx.env?.GEMINI_API_KEY as string | undefined;
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "GEMINI_API_KEY not configured" }), { status: 500 });
+  }
+
+  const db = getDB();
+  if (!db) {
+    return new Response(JSON.stringify({ error: "DB not available" }), { status: 503 });
+  }
+
+  const { results: allRows } = await db
+    .prepare("SELECT id, question_text, options, answers, explanation, category, filled_at FROM questions WHERE exam_id = ? ORDER BY num ASC")
+    .bind(examId)
+    .all<QuestionRow>();
+
+  const allQuestions = allRows ?? [];
+
+  // Determine which questions need filling
+  const candidates = allQuestions.filter((q) => {
+    if (!q.question_text.trim()) return false;
+    // If forceRefill, process everything; otherwise skip already-filled
+    if (!forceRefill && q.filled_at) return false;
+    // Still check if any field is actually missing (even on force recheck)
+    const answers = JSON.parse(q.answers ?? "[]") as string[];
+    const hasMissing = answers.length === 0 || !q.explanation || !q.category;
+    return forceRefill ? true : hasMissing;
+  });
+
+  const skipped = allQuestions.length - candidates.length;
+  const total = candidates.length;
+
+  const ai = new GoogleGenAI({ apiKey });
+  const model = (await getSetting("gemini_model")) ?? "gemini-2.0-flash-preview";
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      const send = (data: object) => {
+        controller.enqueue(enc.encode(`data: ${JSON.stringify(data)}\n\n`));
+      };
+
+      if (total === 0) {
+        send({ done: 0, total: 0, filled: 0, skipped });
+        controller.close();
+        return;
+      }
+
+      send({ done: 0, total, skipped });
+
+      let done = 0;
+      let filled = 0;
+
+      try {
+        for (const q of candidates) {
+          try {
+            const choices = JSON.parse(q.options) as Choice[];
+            const answers = JSON.parse(q.answers ?? "[]") as string[];
+            const missing: string[] = [];
+            if (answers.length === 0) missing.push("answers");
+            if (!q.explanation) missing.push("explanation");
+            if (!q.category) missing.push("category");
+
+            if (missing.length === 0 && !forceRefill) {
+              // Nothing missing — just stamp filled_at and move on
+              await db.prepare("UPDATE questions SET filled_at = datetime('now') WHERE id = ?").bind(q.id).run();
+              done++;
+              send({ done, total });
+              continue;
+            }
+
+            const singleJson = JSON.stringify([{
+              id: q.id,
+              question: q.question_text,
+              choices,
+              missing,
+            }]);
+
+            const template = userPrompt || DEFAULT_FILL_PROMPT;
+            const prompt = template.replace("{questions}", singleJson);
+
+            let results: FillResult[] | null = null;
+            let retries = 2;
+            while (retries >= 0 && results === null) {
+              try {
+                const resp = await ai.models.generateContent({
+                  model,
+                  contents: prompt,
+                  config: { tools: [{ googleSearch: {} }] },
+                });
+                const text = (resp.text ?? "").trim()
+                  .replace(/^```json\s*/i, "").replace(/\s*```$/, "");
+                results = JSON.parse(text) as FillResult[];
+              } catch {
+                retries--;
+              }
+            }
+
+            if (results && results.length > 0) {
+              const result = results[0];
+              const setClauses: string[] = [];
+              const binds: unknown[] = [];
+
+              if (missing.includes("answers") && Array.isArray(result.answers) && result.answers.length > 0) {
+                setClauses.push("answers = ?");
+                binds.push(JSON.stringify(result.answers));
+              }
+              if (missing.includes("explanation") && result.explanation) {
+                setClauses.push("explanation = ?");
+                binds.push(result.explanation);
+              }
+              if (missing.includes("category") && result.category) {
+                setClauses.push("category = ?");
+                binds.push(result.category);
+              }
+
+              if (setClauses.length > 0) {
+                setClauses.push("filled_at = datetime('now')");
+                setClauses.push("updated_at = datetime('now')");
+                binds.push(q.id);
+                await db
+                  .prepare(`UPDATE questions SET ${setClauses.join(", ")} WHERE id = ?`)
+                  .bind(...binds)
+                  .run();
+                filled++;
+              } else {
+                // No fields changed but processed — stamp filled_at
+                await db.prepare("UPDATE questions SET filled_at = datetime('now') WHERE id = ?").bind(q.id).run();
+              }
+            }
+          } catch { /* skip individual failures, move to next */ }
+
+          done++;
+          send({ done, total });
+        }
+
+        send({ done: total, total, filled, skipped });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        send({ error: msg });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/components/AnswersClient.tsx
+++ b/components/AnswersClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { ChevronLeft, ChevronRight, Sparkles, Wand2, ShieldCheck, RotateCcw, Loader2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Sparkles, Wand2, ShieldCheck, Pencil, RotateCcw, Loader2 } from "lucide-react";
 import type { Question, QuizStats } from "@/lib/types";
 import { RichText } from "./RichText";
 import QuestionEditModal from "./QuestionEditModal";
@@ -466,6 +466,13 @@ export default function AnswersClient({ questions: initialQuestions, examName, e
                   title={t("refine")}
                 >
                   <Wand2 size={12} />
+                </button>
+                <button
+                  onClick={() => setEditingQuestion(q)}
+                  className="text-gray-300 hover:text-gray-600 transition-colors"
+                  title={t("edit")}
+                >
+                  <Pencil size={12} />
                 </button>
               </div>
             </div>

--- a/components/ExamDetailClient.tsx
+++ b/components/ExamDetailClient.tsx
@@ -76,10 +76,11 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats, us
 
   // AI Fill
   const [fillStatus, setFillStatus] = useState<"idle" | "filling" | "done" | "error">("idle");
-  const [fillProgress, setFillProgress] = useState<{ done: number; total: number } | null>(null);
+  const [fillProgress, setFillProgress] = useState<{ done: number; total: number; skipped: number } | null>(null);
   const [fillResult, setFillResult] = useState<{ filled: number; skipped: number } | null>(null);
   const [generateTts, setGenerateTts] = useState(false);
   const [ttsProgress, setTtsProgress] = useState<{ done: number; total: number } | null>(null);
+  const [fillForce, setFillForce] = useState(false);
 
   // Wording Fix (bulk refine)
   const [refineStatus, setRefineStatus] = useState<"idle" | "running" | "done" | "error">("idle");
@@ -101,7 +102,7 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats, us
       const res = await fetch(`/api/admin/exams/${encodeURIComponent(exam.id)}/fill`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userPrompt: settings.aiFillPrompt }),
+        body: JSON.stringify({ userPrompt: settings.aiFillPrompt, forceRefill: fillForce }),
       });
       if (!res.body) { setFillStatus("error"); return; }
       const reader = res.body.getReader();
@@ -117,7 +118,7 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats, us
           if (!part.startsWith("data: ")) continue;
           const evt = JSON.parse(part.slice(6)) as { error?: string; done?: number; total?: number; filled?: number; skipped?: number };
           if (evt.error) { setFillStatus("error"); return; }
-          if (evt.total !== undefined) setFillProgress({ done: evt.done ?? 0, total: evt.total });
+          if (evt.total !== undefined) setFillProgress({ done: evt.done ?? 0, total: evt.total, skipped: evt.skipped ?? 0 });
           if (evt.filled !== undefined) setFillResult({ filled: evt.filled, skipped: evt.skipped ?? 0 });
         }
       }
@@ -146,7 +147,7 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats, us
       setFillStatus("error");
       setTimeout(() => setFillStatus("idle"), 3000);
     }
-  }, [exam.id, settings.aiFillPrompt, generateTts, fetchAudio, settings.language]);
+  }, [exam.id, settings.aiFillPrompt, fillForce, generateTts, fetchAudio, settings.language]);
 
   const startRefine = useCallback(async () => {
     setRefineStatus("running");
@@ -760,23 +761,35 @@ export default function ExamDetailClient({ exam, categoryStats: initialStats, us
                 }`}
               >
                 {fillStatus === "filling"
-                  ? <><Loader2 size={14} className="animate-spin" /> AI Fill {fillProgress ? `${fillProgress.done}/${fillProgress.total}` : "…"}</>
+                  ? <><Loader2 size={14} className="animate-spin" /> AI Fill {fillProgress ? `${fillProgress.done}/${fillProgress.total}${fillProgress.skipped ? ` (${fillProgress.skipped} skipped)` : ""}` : "…"}</>
                   : fillStatus === "done"
                   ? <><Sparkles size={14} /> {fillResult ? `Filled ${fillResult.filled} · Skipped ${fillResult.skipped}` : "Done"}</>
                   : fillStatus === "error"
                   ? <><Sparkles size={14} /> Fill failed</>
                   : <><Sparkles size={14} /> AI Fill</>}
               </button>
-              <label className="flex items-center gap-2 cursor-pointer select-none self-start">
-                <input
-                  type="checkbox"
-                  checked={generateTts}
-                  onChange={(e) => setGenerateTts(e.target.checked)}
-                  disabled={fillStatus === "filling"}
-                  className="w-3.5 h-3.5 rounded accent-gray-700"
-                />
-                <span className="text-xs text-gray-400">TTS も生成する</span>
-              </label>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={generateTts}
+                    onChange={(e) => setGenerateTts(e.target.checked)}
+                    disabled={fillStatus === "filling"}
+                    className="w-3.5 h-3.5 rounded accent-gray-700"
+                  />
+                  <span className="text-xs text-gray-400">TTS も生成する</span>
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={fillForce}
+                    onChange={(e) => setFillForce(e.target.checked)}
+                    disabled={fillStatus === "filling"}
+                    className="w-3.5 h-3.5 rounded accent-gray-700"
+                  />
+                  <span className="text-xs text-gray-400">Re-fill already filled</span>
+                </label>
+              </div>
               {ttsProgress && (
                 <div className="flex flex-col gap-1">
                   <div className="flex items-center justify-between text-xs text-gray-400">

--- a/migrations/0017_add_fill_timestamps.sql
+++ b/migrations/0017_add_fill_timestamps.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions ADD COLUMN filled_at TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary
- **AI Fill**: changed from batch-10 to one-by-one processing so each question is saved immediately — partial runs are no longer lost on timeout
- **AI Fill**: added `filled_at` timestamp (migration 0017) to skip already-processed questions on retry; force-refill checkbox to override
- **AI Wording Fix / Fact Check**: already saved per-question; skip flags (`fact_checked_at`) already in place
- **Answers screen**: added Pencil/Edit button to open QuestionEditModal (which contains the version history panel)

## Migrations needed
- `0017_add_fill_timestamps.sql`: `ALTER TABLE questions ADD COLUMN filled_at TEXT DEFAULT NULL`

## Test plan
- [ ] AI Fill on a large exam — interrupt mid-way, verify already-processed questions have data saved
- [ ] Re-run Fill — already-filled questions are skipped (filled count = 0, skip count = N)
- [ ] Check "Re-fill already filled" → all questions re-processed
- [ ] Answers screen: Pencil button opens edit modal with History panel accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)